### PR TITLE
Fix #1: standardize sprint-wip.md path to .sprints/sprint-wip.md

### DIFF
--- a/sprint-close.md
+++ b/sprint-close.md
@@ -4,7 +4,7 @@ You are a weekly sprint review and planning assistant — **Stage 2** (first wor
 
 ## STEP 1: Load draft
 
-Read the file `~/sprint-wip.md`.
+Read the file `.sprints/sprint-wip.md`.
 Extract: sprint period, generation date, draft content.
 Tell the user: "Found the draft for sprint [period]. Collecting missing data now."
 
@@ -63,4 +63,4 @@ Ask only these 2 questions in one message:
 1. "Did anything get missed in **Outcomes** or **Outputs** from the weekend?"
 2. "Is the **week goal** and the **priority order** correct?"
 
-Incorporate feedback, deliver the final version, and **delete** `~/sprint-wip.md`.
+Incorporate feedback, deliver the final version, and **delete** `.sprints/sprint-wip.md`.

--- a/sprint-start.md
+++ b/sprint-start.md
@@ -197,7 +197,7 @@ Items are numbered sequentially across all projects.]
 ## STEP 5: Save draft
 
 Save the full draft (day plan + document) to:
-`~/sprint-wip.md`
+`.sprints/sprint-wip.md`
 
 Include at the top:
 ```
@@ -209,5 +209,5 @@ Include at the top:
 ## STEP 6: Confirm
 
 Tell the user:
-- "Draft saved to ~/sprint-wip.md. Use `/sprint-close` on Monday to complete it."
+- "Draft saved to .sprints/sprint-wip.md. Use `/sprint-close` on Monday to complete it."
 - Ask: "Does the day plan look right? Anything to adjust in the draft?"

--- a/sprint-update.md
+++ b/sprint-update.md
@@ -4,7 +4,7 @@ You are a weekly sprint review and planning assistant — **Edit mode**.
 
 ## STEP 1: Load draft
 
-Read the file `~/sprint-wip.md`.
+Read the file `.sprints/sprint-wip.md`.
 Display the full content to the user exactly as-is (day plan + document).
 
 ---
@@ -20,6 +20,6 @@ Apply all changes in one pass.
 
 ## STEP 3: Save
 
-Overwrite `~/sprint-wip.md` with the updated content, preserving the `<!-- sprint-wip: ... -->` header.
+Overwrite `.sprints/sprint-wip.md` with the updated content, preserving the `<!-- sprint-wip: ... -->` header.
 
 Confirm: "Done. Draft updated."


### PR DESCRIPTION
## Summary

Standardiza o caminho do draft `sprint-wip.md` em `.sprints/sprint-wip.md` em todos os slash commands.

`upload-sprint.js`, `README.md` e `SETUP.md` já usam `.sprints/sprint-wip.md`, mas `sprint-start.md`, `sprint-update.md` e `sprint-close.md` referenciavam `~/sprint-wip.md`. Isso fazia com que o draft nunca chegasse ao lugar que o `upload-sprint.js` lê, quebrando o fluxo para o Google Docs.

## Changes

- `sprint-start.md`: STEP 5 (save) e STEP 6 (mensagem de confirmação)
- `sprint-update.md`: STEP 1 (load) e STEP 3 (save)
- `sprint-close.md`: STEP 1 (load) e STEP 5 (delete)

## Test plan

- [ ] Rodar `/sprint-start` e confirmar que o draft é salvo em `.sprints/sprint-wip.md`
- [ ] Rodar `/sprint-update` e confirmar que lê/escreve no mesmo caminho
- [ ] Rodar `/sprint-close` seguido de `node upload-sprint.js` e verificar que o upload encontra o arquivo

Fixes #1

---
_Generated by [Claude Code](https://claude.ai/code/session_01JeDEMt3QKappRVbLLUY9PE)_