### PR TITLE
Fix #2: keep sprint-wip.md after /sprint-close so upload can read it

### DIFF
--- a/sprint-close.md
+++ b/sprint-close.md
@@ -4,7 +4,7 @@ You are a weekly sprint review and planning assistant — **Stage 2** (first wor
 
 ## STEP 1: Load draft
 
-Read the file `~/sprint-wip.md`.
+Read the file `.sprints/sprint-wip.md`.
 Extract: sprint period, generation date, draft content.
 Tell the user: "Found the draft for sprint [period]. Collecting missing data now."
 
@@ -63,4 +63,4 @@ Ask only these 2 questions in one message:
 1. "Did anything get missed in **Outcomes** or **Outputs** from the weekend?"
 2. "Is the **week goal** and the **priority order** correct?"
 
-Incorporate feedback, deliver the final version, and **delete** `~/sprint-wip.md`.
+Incorporate feedback, deliver the final version, and **delete** `.sprints/sprint-wip.md`.

--- a/sprint-close.md
+++ b/sprint-close.md
@@ -63,4 +63,6 @@ Ask only these 2 questions in one message:
 1. "Did anything get missed in **Outcomes** or **Outputs** from the weekend?"
 2. "Is the **week goal** and the **priority order** correct?"
 
-Incorporate feedback, deliver the final version, and **delete** `.sprints/sprint-wip.md`.
+Incorporate feedback and deliver the final version.
+
+Leave `.sprints/sprint-wip.md` in place — `upload-sprint.js` reads it to push the review into Google Docs. Delete the file manually once you no longer need it.

--- a/sprint-start.md
+++ b/sprint-start.md
@@ -197,7 +197,7 @@ Items are numbered sequentially across all projects.]
 ## STEP 5: Save draft
 
 Save the full draft (day plan + document) to:
-`~/sprint-wip.md`
+`.sprints/sprint-wip.md`
 
 Include at the top:
 ```
@@ -209,5 +209,5 @@ Include at the top:
 ## STEP 6: Confirm
 
 Tell the user:
-- "Draft saved to ~/sprint-wip.md. Use `/sprint-close` on Monday to complete it."
+- "Draft saved to .sprints/sprint-wip.md. Use `/sprint-close` on Monday to complete it."
 - Ask: "Does the day plan look right? Anything to adjust in the draft?"

--- a/sprint-update.md
+++ b/sprint-update.md
@@ -4,7 +4,7 @@ You are a weekly sprint review and planning assistant — **Edit mode**.
 
 ## STEP 1: Load draft
 
-Read the file `~/sprint-wip.md`.
+Read the file `.sprints/sprint-wip.md`.
 Display the full content to the user exactly as-is (day plan + document).
 
 ---
@@ -20,6 +20,6 @@ Apply all changes in one pass.
 
 ## STEP 3: Save
 
-Overwrite `~/sprint-wip.md` with the updated content, preserving the `<!-- sprint-wip: ... -->` header.
+Overwrite `.sprints/sprint-wip.md` with the updated content, preserving the `<!-- sprint-wip: ... -->` header.
 
 Confirm: "Done. Draft updated."


### PR DESCRIPTION
## Summary

`/sprint-close` apagava `sprint-wip.md` no último passo, mas o `README.md` documenta `node upload-sprint.js` como o passo imediatamente seguinte — e o upload lê exatamente esse arquivo. O fluxo quebrava: depois de `/sprint-close`, o upload sempre falhava com `sprint-wip.md not found`.

## Change

Remove o `**delete**` do último passo de `sprint-close.md` e deixa claro que a limpeza do arquivo é manual, para permitir que `upload-sprint.js` consiga lê-lo.

## Test plan

- [ ] Rodar `/sprint-start` → `/sprint-close` → `node upload-sprint.js` e verificar que o upload encontra o arquivo.
- [ ] Confirmar que o fluxo documentado em `README.md:37-42` (upload após close) funciona ponta a ponta.

Fixes #2

---
_Generated by [Claude Code](https://claude.ai/code/session_01JeDEMt3QKappRVbLLUY9PE)_