### PR TITLE
Fix #4: align H1 comment with actual underscore replacement

### DIFF
--- a/insert-sprint.gs
+++ b/insert-sprint.gs
@@ -41,10 +41,10 @@ function insertSprintReview(fileContent) {
     // Empty lines
     if (line.trim() === '') continue;
 
-    // H1: # 19/Abr -----  (replace hyphens with em-dashes for continuous line)
+    // H1: # 19/Abr -----  (replace hyphen run with underscores to render as a continuous line)
     if (/^# .+\s-{3,}/.test(line)) {
       let text = line.replace(/^# /, '').trim();
-      // Replace the trailing hyphen run with em-dashes (wider, render as a continuous line)
+      // Underscores render flush together as a solid baseline rule in Google Docs
       text = text.replace(/-{3,}\s*$/, '_'.repeat(20));
       body.insertParagraph(insertPos++, text)
           .setHeading(DocumentApp.ParagraphHeading.HEADING1);


### PR DESCRIPTION
## Summary

Os dois comentários no bloco H1 de `insert-sprint.gs` diziam que a run de hifens era trocada por **em-dashes**, mas o código usa `'_'.repeat(20)`. O commit `4055ba6 "Render H1 trailing dashes as continuous underscore line"` mostra que a troca para underscore foi intencional; o comentário só ficou desatualizado.

## Change

Atualiza os dois comentários para refletir o comportamento real (underscore).

## Test plan

Puramente documental — sem mudança de comportamento a testar.

Fixes #4

---
_Generated by [Claude Code](https://claude.ai/code/session_01JeDEMt3QKappRVbLLUY9PE)_