### PR TITLE
Fix #6: make H1 trailing hyphen run optional

### DIFF
--- a/insert-sprint.gs
+++ b/insert-sprint.gs
@@ -49,10 +49,9 @@ function insertSprintReview(fileContent) {
     // Empty lines
     if (line.trim() === '') continue;
 
-    // H1: # 19/Abr -----  (replace hyphen run with underscores to render as a continuous line)
-    if (/^# .+\s-{3,}/.test(line)) {
+    // H1: # 19/Abr [-----]  (trailing hyphen run optional — replaced with underscores to render as a continuous line)
+    if (/^# \d+\//.test(line)) {
       let text = line.replace(/^# /, '').trim();
-      // Underscores render flush together as a solid baseline rule in Google Docs
       text = text.replace(/-{3,}\s*$/, '_'.repeat(20));
       body.insertParagraph(insertPos++, text)
           .setHeading(DocumentApp.ParagraphHeading.HEADING1);


### PR DESCRIPTION
## Summary

O branch de H1 em `insert-sprint.gs` exigia a "régua" final de hifens (`/^# .+\s-{3,}/`). Se o draft chegasse sem ela (ex.: `# 19/Abr`), a linha caía para o handler de parágrafo genérico e o título do sprint virava texto comum no Google Doc — silenciosamente.

## Change

Troca a regex de H1 por `/^# \d+\//` — exatamente o mesmo padrão que o `startIdx` já usa (`insert-sprint.gs:14`). A substituição de `-{3,}` por underscores vira um no-op quando a régua está ausente; quando presente, o comportamento é idêntico ao anterior.

Também remove o comentário inline redundante (a intenção do replace já é clara).

## Test plan

- [ ] Draft com `# 19/Abr -------------------------------------` → H1 com régua de underscore (comportamento atual).
- [ ] Draft com `# 19/Abr` (sem régua) → agora também vira H1 (antes caía para parágrafo).
- [ ] Verificar que linhas `# Qualquer coisa` sem `D/Month` (ex.: headings genéricos que um usuário possa digitar por engano) continuam caindo para parágrafo — preservando a robustez contra headings não-sprint.

Fixes #6

---
_Generated by [Claude Code](https://claude.ai/code/session_01JeDEMt3QKappRVbLLUY9PE)_