### PR TITLE
Fix #7: fail fast when sprint-wip.md has no H1 heading

### DIFF
--- a/insert-sprint.gs
+++ b/insert-sprint.gs
@@ -9,12 +9,15 @@ function insertSprintReview(fileContent) {
   const lines = fileContent.split('\n');
 
   // Find where the review starts (first "# DD/Mon ---" heading)
-  let startIdx = 0;
+  let startIdx = -1;
   for (let i = 0; i < lines.length; i++) {
     if (/^# \d+\//.test(lines[i])) {
       startIdx = i;
       break;
     }
+  }
+  if (startIdx === -1) {
+    throw new Error('No H1 sprint heading found (expected a line matching "# D/Month ..."). Check sprint-wip.md format.');
   }
 
   let insertPos = 0;


### PR DESCRIPTION
## Summary

Quando `insert-sprint.gs` não encontrava a heading de H1 (`# D/Month ...`), `startIdx` ficava em `0` e o loop processava o arquivo inteiro, inserindo qualquer conteúdo que estivesse antes da review real (ex.: metadados, frontmatter, arquivo malformado) no Google Doc. O usuário recebia uma execução aparentemente bem-sucedida com lixo no doc.

## Change

- Inicializa `startIdx` em `-1`.
- Se nenhum H1 for encontrado após a varredura, lança `Error` explícito — o `upload-sprint.js:69-71` já repassa mensagens de erro de Apps Script para o usuário.

## Test plan

- [ ] Arquivo com `# 19/Abr ...` → comportamento igual ao atual (sem regressão).
- [ ] Arquivo sem nenhum `# D/Month` → passa a lançar "No H1 sprint heading found..." em vez de inserir conteúdo silenciosamente.
- [ ] Arquivo só com o comentário `<!-- sprint-wip: ... -->` → também passa a falhar explicitamente.

Fixes #7

---
_Generated by [Claude Code](https://claude.ai/code/session_01JeDEMt3QKappRVbLLUY9PE)_