### PR TITLE
Fix #8: restrict token.json to mode 0600

### DIFF
--- a/upload-sprint.js
+++ b/upload-sprint.js
@@ -27,12 +27,15 @@ async function loadSavedCredentials() {
 async function saveCredentials(client) {
   const content = JSON.parse(fs.readFileSync(CREDENTIALS_PATH, 'utf8'));
   const key = content.installed || content.web;
-  fs.writeFileSync(TOKEN_PATH, JSON.stringify({
+  const payload = JSON.stringify({
     type: 'authorized_user',
     client_id: key.client_id,
     client_secret: key.client_secret,
     refresh_token: client.credentials.refresh_token,
-  }));
+  });
+  // mode 0o600: token contains a long-lived refresh_token; restrict to the owning user
+  fs.writeFileSync(TOKEN_PATH, payload, { mode: 0o600 });
+  fs.chmodSync(TOKEN_PATH, 0o600);
 }
 
 async function authorize() {


### PR DESCRIPTION
## Summary

`token.json` guarda um `refresh_token` OAuth de longa duração + `client_id`/`client_secret`. `fs.writeFileSync` sem `mode` usa o umask default (geralmente 0o644 → world-readable), expondo credenciais em sistemas multi-usuário.

## Change

- Passa `{ mode: 0o600 }` para `fs.writeFileSync` — aplica em criação.
- `fs.chmodSync(TOKEN_PATH, 0o600)` logo após — garante `0600` mesmo quando o arquivo já existia (nesse caso o `mode` do `writeFileSync` é ignorado).

## Test plan

- [ ] Apagar `token.json` local, rodar `node upload-sprint.js`, autenticar, e verificar `stat -c '%a' token.json` → `600`.
- [ ] Tocar `token.json` com `chmod 644 token.json`, rodar de novo, e verificar que a permissão é corrigida para `600`.
- [ ] Em Windows o conceito de permissão é diferente; `fs.chmodSync` em NTFS vira um no-op funcional, sem erro.

Fixes #8

---
_Generated by [Claude Code](https://claude.ai/code/session_01JeDEMt3QKappRVbLLUY9PE)_