### PR TITLE
Setup CI + unit tests for parser logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Syntax check (Node JS files)
+        run: |
+          node --check upload-sprint.js
+          node --check find-script-id.js
+          node --check test-script.js
+          node --check parser.js
+
+      - name: Run tests
+        run: npm test

--- a/__tests__/parser.test.js
+++ b/__tests__/parser.test.js
@@ -1,0 +1,151 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  parseInlineBold,
+  findStartIdx,
+  classifyLine,
+  parseTable,
+} = require('../parser');
+
+test('parseInlineBold: single bold run', () => {
+  const { text, ranges } = parseInlineBold('hello **world**');
+  assert.equal(text, 'hello world');
+  assert.deepEqual(ranges, [[6, 10]]);
+});
+
+test('parseInlineBold: multiple bold runs', () => {
+  const { text, ranges } = parseInlineBold('**a** and **b**');
+  assert.equal(text, 'a and b');
+  assert.deepEqual(ranges, [[0, 0], [6, 6]]);
+});
+
+test('parseInlineBold: no bold markers returns empty ranges', () => {
+  const { text, ranges } = parseInlineBold('plain text');
+  assert.equal(text, 'plain text');
+  assert.deepEqual(ranges, []);
+});
+
+test('parseInlineBold: unclosed marker is kept literal', () => {
+  const { text, ranges } = parseInlineBold('hello **world');
+  assert.equal(text, 'hello **world');
+  assert.deepEqual(ranges, []);
+});
+
+test('parseInlineBold: empty bold run (****) is skipped', () => {
+  const { text, ranges } = parseInlineBold('a****b');
+  assert.equal(text, 'ab');
+  assert.deepEqual(ranges, []);
+});
+
+test('findStartIdx: finds the first "# D/Month" heading', () => {
+  const lines = ['<!-- header -->', '', '# 19/Abr ------', '## other'];
+  assert.equal(findStartIdx(lines), 2);
+});
+
+test('findStartIdx: returns -1 when no heading (regression for #7)', () => {
+  const lines = ['<!-- header -->', 'plain text'];
+  assert.equal(findStartIdx(lines), -1);
+});
+
+test('findStartIdx: ignores "# text" without leading digit', () => {
+  assert.equal(findStartIdx(['# Overview', '# 5/Mar']), 1);
+});
+
+test('classifyLine: h1 with trailing hyphen rule', () => {
+  const r = classifyLine('# 19/Abr -------------------------------------');
+  assert.equal(r.type, 'h1');
+  assert.equal(r.text, '19/Abr ' + '_'.repeat(20));
+});
+
+test('classifyLine: h1 without trailing hyphens (regression for #6)', () => {
+  const r = classifyLine('# 19/Abr');
+  assert.equal(r.type, 'h1');
+  assert.equal(r.text, '19/Abr');
+});
+
+test('classifyLine: h2 with italic period', () => {
+  const r = classifyLine('## Sprint Review *(Mar 30-Apr 5, 5 workdays)*');
+  assert.equal(r.type, 'h2');
+  assert.equal(r.mainText, 'Sprint Review');
+  assert.equal(r.italicText, '(Mar 30-Apr 5, 5 workdays)');
+});
+
+test('classifyLine: h2 without italic part', () => {
+  const r = classifyLine('## Just a heading');
+  assert.equal(r.type, 'h2');
+  assert.equal(r.mainText, 'Just a heading');
+  assert.equal(r.italicText, undefined);
+});
+
+test('classifyLine: h3', () => {
+  const r = classifyLine('### Outcomes');
+  assert.equal(r.type, 'h3');
+  assert.equal(r.text, 'Outcomes');
+});
+
+test('classifyLine: bullet with inline bold preserves ranges (regression for #3)', () => {
+  const r = classifyLine('* Meditate **7 days**');
+  assert.equal(r.type, 'bullet');
+  assert.equal(r.text, 'Meditate 7 days');
+  assert.deepEqual(r.ranges, [[9, 14]]);
+});
+
+test('classifyLine: numbered item with inline bold', () => {
+  const r = classifyLine('1. **Health**');
+  assert.equal(r.type, 'numbered');
+  assert.equal(r.text, 'Health');
+  assert.deepEqual(r.ranges, [[0, 5]]);
+});
+
+test('classifyLine: standalone **bold** line is bold-header', () => {
+  const r = classifyLine('**Personal**');
+  assert.equal(r.type, 'bold-header');
+  assert.equal(r.text, 'Personal');
+});
+
+test('classifyLine: HTML comment is ignored', () => {
+  assert.equal(classifyLine('<!-- sprint-wip: ... -->').type, 'comment');
+});
+
+test('classifyLine: table row', () => {
+  const r = classifyLine('| Improvement | Result |');
+  assert.equal(r.type, 'table-row');
+  assert.equal(r.raw, '| Improvement | Result |');
+});
+
+test('classifyLine: blank line is empty', () => {
+  assert.equal(classifyLine('').type, 'empty');
+  assert.equal(classifyLine('   ').type, 'empty');
+});
+
+test('classifyLine: paragraph with inline bold keeps ranges', () => {
+  const r = classifyLine('Some **bold** text');
+  assert.equal(r.type, 'paragraph');
+  assert.equal(r.text, 'Some bold text');
+  assert.deepEqual(r.ranges, [[5, 8]]);
+});
+
+test('parseTable: filters separator rows and parses cells', () => {
+  const lines = [
+    '| Improvement | Result |',
+    '| :---- | :---: |',
+    '| Work +2h | **3 / 5** |',
+  ];
+  const rows = parseTable(lines);
+  assert.equal(rows.length, 2);
+  assert.equal(rows[0][0].text, 'Improvement');
+  assert.equal(rows[0][1].text, 'Result');
+  assert.equal(rows[1][1].text, '3 / 5');
+  assert.deepEqual(rows[1][1].ranges, [[0, 4]]);
+});
+
+test('parseTable: keeps inline bold ranges in body cells (regression for #3)', () => {
+  const lines = [
+    '| Metric | Value |',
+    '| :---- | :---: |',
+    '| Sleep | **7h30** / 8h |',
+  ];
+  const rows = parseTable(lines);
+  assert.equal(rows[1][1].text, '7h30 / 8h');
+  assert.deepEqual(rows[1][1].ranges, [[0, 3]]);
+});

--- a/insert-sprint.gs
+++ b/insert-sprint.gs
@@ -1,3 +1,8 @@
+// Apps Script entry point. The pure parsing helpers (parseInlineBold,
+// stripBold, and the regex-based dispatching) are duplicated in parser.js at
+// the repo root — that file is what the Node test suite (__tests__/parser.test.js)
+// runs against. Keep the two in sync when editing either.
+
 function insertSprintReview(fileContent) {
   const DOC_ID = PropertiesService.getScriptProperties().getProperty('DOC_ID');
   if (!DOC_ID) { throw new Error('DOC_ID not configured in Script Properties'); }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
   "description": "Sprint review automation with Google Docs integration",
   "main": "upload-sprint.js",
   "scripts": {
-    "upload": "node upload-sprint.js"
+    "upload": "node upload-sprint.js",
+    "test": "node --test \"__tests__/**/*.test.js\""
+  },
+  "engines": {
+    "node": ">=18"
   },
   "dependencies": {
     "@google-cloud/local-auth": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "upload-sprint.js",
   "scripts": {
     "upload": "node upload-sprint.js",
-    "test": "node --test \"__tests__/**/*.test.js\""
+    "test": "node --test __tests__/parser.test.js"
   },
   "engines": {
     "node": ">=18"

--- a/parser.js
+++ b/parser.js
@@ -1,0 +1,106 @@
+// Pure parsing helpers used by insert-sprint.gs.
+//
+// Apps Script cannot import Node modules, so insert-sprint.gs carries its own
+// copy of these functions. Keep the two implementations in sync — the tests in
+// __tests__/parser.test.js run against this file and catch regressions here;
+// manual verification is still required for the .gs copy.
+
+// Returns { text, ranges } where text has **...** markers removed and
+// ranges is an array of [startIndex, endIndex] (both inclusive) pointing at
+// the positions of the originally bold runs in the stripped text.
+function parseInlineBold(raw) {
+  const ranges = [];
+  let text = '';
+  let i = 0;
+  while (i < raw.length) {
+    if (raw.charAt(i) === '*' && raw.charAt(i + 1) === '*') {
+      const end = raw.indexOf('**', i + 2);
+      if (end === -1) {
+        text += raw.substring(i);
+        break;
+      }
+      const boldText = raw.substring(i + 2, end);
+      if (boldText.length > 0) {
+        const startPos = text.length;
+        text += boldText;
+        ranges.push([startPos, text.length - 1]);
+      }
+      i = end + 2;
+    } else {
+      text += raw.charAt(i);
+      i++;
+    }
+  }
+  return { text, ranges };
+}
+
+// Finds the first line matching the sprint H1 pattern ("# D/Month ...").
+// Returns the line index, or -1 if none found.
+function findStartIdx(lines) {
+  for (let i = 0; i < lines.length; i++) {
+    if (/^# \d+\//.test(lines[i])) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+// Classifies a single line into a structured descriptor.
+// Types: comment, table-row, empty, h1, h2, h3, bold-header, bullet,
+// numbered, paragraph.
+function classifyLine(line) {
+  if (line.trim().startsWith('<!--')) return { type: 'comment' };
+  if (line.startsWith('|')) return { type: 'table-row', raw: line };
+  if (line.trim() === '') return { type: 'empty' };
+
+  if (/^# \d+\//.test(line)) {
+    let text = line.replace(/^# /, '').trim();
+    text = text.replace(/-{3,}\s*$/, '_'.repeat(20));
+    return { type: 'h1', text };
+  }
+
+  if (line.startsWith('## ')) {
+    const raw = line.replace(/^## /, '').trim();
+    const match = raw.match(/^(.+?)\s+\*(.+)\*$/);
+    if (match) {
+      return { type: 'h2', mainText: match[1], italicText: match[2] };
+    }
+    return { type: 'h2', mainText: raw };
+  }
+
+  if (line.startsWith('### ')) {
+    return { type: 'h3', text: line.replace(/^### /, '').trim() };
+  }
+
+  if (/^\*\*[^*]+\*\*$/.test(line)) {
+    return {
+      type: 'bold-header',
+      text: line.replace(/^\*\*/, '').replace(/\*\*$/, '').trim(),
+    };
+  }
+
+  if (/^[*-] /.test(line)) {
+    const parsed = parseInlineBold(line.replace(/^[*-] /, '').trim());
+    return { type: 'bullet', text: parsed.text, ranges: parsed.ranges };
+  }
+
+  if (/^\d+\. /.test(line)) {
+    const parsed = parseInlineBold(line.replace(/^\d+\. /, '').trim());
+    return { type: 'numbered', text: parsed.text, ranges: parsed.ranges };
+  }
+
+  const parsed = parseInlineBold(line.trim());
+  if (!parsed.text) return { type: 'empty' };
+  return { type: 'paragraph', text: parsed.text, ranges: parsed.ranges };
+}
+
+// Parses buffered table lines into an array of rows, each a list of
+// { text, ranges } cells. Separator rows (| :---- | :---: |) are skipped.
+function parseTable(tableLines) {
+  const dataLines = tableLines.filter(l => !/^\|[\s:|-]+\|$/.test(l));
+  return dataLines.map(row =>
+    row.split('|').slice(1, -1).map(cell => parseInlineBold(cell.trim()))
+  );
+}
+
+module.exports = { parseInlineBold, findStartIdx, classifyLine, parseTable };


### PR DESCRIPTION
## Summary

Sobe CI básico + testes unitários para a lógica de parsing, fechando o gap que a issue #16 identificou: até agora PRs eram mergeados sem nenhum check automatizado.

## Changes

### `parser.js` — novo
Módulo Node puro com as 4 funções de parsing reaproveitáveis:
- `parseInlineBold(raw)` → `{ text, ranges }`
- `findStartIdx(lines)` → índice do H1 ou `-1`
- `classifyLine(line)` → descritor estruturado (`h1`, `h2`, `bullet`, …)
- `parseTable(tableLines)` → array de linhas com `parseInlineBold` aplicado a cada célula

**Trade-off consciente:** Apps Script não importa módulos Node, então `insert-sprint.gs` mantém sua própria cópia da lógica. Adicionei uma nota no topo do `.gs` pedindo para manter em sync. Os tests do `parser.js` pegam regressões aqui; a verificação manual no Apps Script ainda é necessária para confirmar que o `.gs` foi atualizado junto.

### `__tests__/parser.test.js` — novo
22 testes cobrindo:
- Happy path para cada tipo de linha
- **Regressão #3** — negrito inline preservado em bullets, numbered lists, parágrafos e células de tabela
- **Regressão #6** — H1 sem "régua" de hifens
- **Regressão #7** — `findStartIdx` retorna `-1` quando não acha heading

Usa `node:test` nativo — zero dependências novas.

### `.github/workflows/ci.yml` — novo
Roda em PRs e pushes para `master`:
- `npm ci`
- `node --check` em cada `.js`
- `npm test`

### `package.json`
- Adiciona script `test`
- Adiciona `engines.node >= 18` (necessário para `node --test`)

## Test plan

- [ ] Após merge, abrir um PR de teste e confirmar que o job aparece em "Checks"
- [ ] Quebrar intencionalmente um regex em `parser.js` e confirmar que o CI pega
- [ ] Confirmar que `npm test` roda localmente

```
$ npm test
# tests 22
# pass 22
# fail 0
```

## Não escopo
- Refatorar `insert-sprint.gs` para consumir `parser.js` (requer bundler/clasp) — issue de followup.
- Testes end-to-end contra Google Docs (precisa credenciais).

Fixes #16

---
_Generated by [Claude Code](https://claude.ai/code/session_01JeDEMt3QKappRVbLLUY9PE)_