### PR TITLE
Fix #18: also chmod 0600 token.json on load

### DIFF
--- a/upload-sprint.js
+++ b/upload-sprint.js
@@ -18,6 +18,7 @@ const DEPLOY_ID = process.env.APPS_SCRIPT_DEPLOY_ID;
 async function loadSavedCredentials() {
   try {
     const content = fs.readFileSync(TOKEN_PATH, 'utf8');
+    try { fs.chmodSync(TOKEN_PATH, 0o600); } catch {}
     return google.auth.fromJSON(JSON.parse(content));
   } catch {
     return null;


### PR DESCRIPTION
## Summary

#15 deixa `token.json` com modo `0600` ao criar/atualizar, mas quem já tem um `token.json` gerado antes (com `0644`) e nunca reautentica mantém o token aberto para outros usuários. Refresh tokens OAuth duram bastante, então isso pode persistir por muito tempo.

## Change

Adiciona um `fs.chmodSync(TOKEN_PATH, 0o600)` no caminho feliz de `loadSavedCredentials`. `try/catch` interno evita que filesystems que não suportam chmod (Windows, mounts de rede) quebrem o login.

## Test plan

- [ ] Criar `token.json` com `chmod 0644 token.json`, rodar `node upload-sprint.js`, verificar que vira `0600` após o load.
- [ ] Rodar em Windows ou mount sem chmod → login continua funcionando (o `catch` absorve o erro).

Fixes #18

---
_Generated by [Claude Code](https://claude.ai/code/session_01JeDEMt3QKappRVbLLUY9PE)_