### PR TITLE
Fix #2 (refeito): manter sprint-wip.md após /sprint-close

### DIFF
--- a/sprint-close.md
+++ b/sprint-close.md
@@ -60,4 +60,6 @@ Faça apenas 2 perguntas em uma mensagem:
 1. "Algo faltou nos **Outcomes** ou **Outputs** do fim de semana?"
 2. "O **objetivo da semana** e as **prioridades** estão corretos?"
 
-Incorpore o feedback, entregue a versão final pronta para copiar para o Google Docs e **delete o arquivo** `/c/Users/vjpix/claude-sprint-review/.sprints/sprint-wip.md`.
+Incorpore o feedback e entregue a versão final pronta para copiar para o Google Docs.
+
+Mantenha o arquivo `/c/Users/vjpix/claude-sprint-review/.sprints/sprint-wip.md` no lugar — `upload-sprint.js` lê esse arquivo para inserir a review no Google Doc. Apague manualmente quando não precisar mais.


### PR DESCRIPTION
## Summary

Refaz a fix originalmente proposta em #10 contra a nova versão em português do `sprint-close.md` (após o sync `352b7ef`).

`/sprint-close` apagava `sprint-wip.md` no último passo, mas o `README.md` documenta `node upload-sprint.js` como o passo imediatamente seguinte — e o upload lê exatamente esse arquivo. O fluxo quebrava: depois de `/sprint-close`, o upload sempre falhava com `sprint-wip.md not found`.

## Change

Remove o `**delete o arquivo**` do PASSO 5 de `sprint-close.md` (linha 63) e deixa claro que a limpeza do arquivo é manual.

## Test plan

- [ ] Rodar `/sprint-start` → `/sprint-close` → `node upload-sprint.js` e verificar que o upload encontra o arquivo.

Fixes #2

(Substitui #10, que foi escrita contra a versão antiga em inglês e ficou inviável de mergear após o sync.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JeDEMt3QKappRVbLLUY9PE)_