### PR TITLE
Fix #21: strip inline **bold** markers in H1/H2/H3 headings

### DIFF
--- a/__tests__/parser.test.js
+++ b/__tests__/parser.test.js
@@ -55,6 +55,7 @@ test('classifyLine: h1 with trailing hyphen rule', () => {
   const r = classifyLine('# 19/Abr -------------------------------------');
   assert.equal(r.type, 'h1');
   assert.equal(r.text, '19/Abr ' + '_'.repeat(20));
+  assert.deepEqual(r.ranges, []);
 });
 
 test('classifyLine: h1 without trailing hyphens (regression for #6)', () => {
@@ -63,11 +64,28 @@ test('classifyLine: h1 without trailing hyphens (regression for #6)', () => {
   assert.equal(r.text, '19/Abr');
 });
 
+test('classifyLine: h1 with inline bold after the date strips markers (regression for #21)', () => {
+  // The H1 regex requires a digit right after "# ", so bold must come after the date.
+  const r = classifyLine('# 19/Abr **special** -----');
+  assert.equal(r.type, 'h1');
+  assert.equal(r.text, '19/Abr special ' + '_'.repeat(20));
+  assert.deepEqual(r.ranges, [[7, 13]]);
+});
+
 test('classifyLine: h2 with italic period', () => {
   const r = classifyLine('## Sprint Review *(Mar 30-Apr 5, 5 workdays)*');
   assert.equal(r.type, 'h2');
   assert.equal(r.mainText, 'Sprint Review');
   assert.equal(r.italicText, '(Mar 30-Apr 5, 5 workdays)');
+  assert.deepEqual(r.ranges, []);
+});
+
+test('classifyLine: h2 with bold in mainText and italic period (regression for #21)', () => {
+  const r = classifyLine('## **Sprint** Review *(period)*');
+  assert.equal(r.type, 'h2');
+  assert.equal(r.mainText, 'Sprint Review');
+  assert.equal(r.italicText, '(period)');
+  assert.deepEqual(r.ranges, [[0, 5]]);
 });
 
 test('classifyLine: h2 without italic part', () => {
@@ -77,10 +95,26 @@ test('classifyLine: h2 without italic part', () => {
   assert.equal(r.italicText, undefined);
 });
 
+test('classifyLine: h2 inline bold without italic (regression for #21)', () => {
+  const r = classifyLine('## **Sprint** Review');
+  assert.equal(r.type, 'h2');
+  assert.equal(r.mainText, 'Sprint Review');
+  assert.equal(r.italicText, undefined);
+  assert.deepEqual(r.ranges, [[0, 5]]);
+});
+
 test('classifyLine: h3', () => {
   const r = classifyLine('### Outcomes');
   assert.equal(r.type, 'h3');
   assert.equal(r.text, 'Outcomes');
+  assert.deepEqual(r.ranges, []);
+});
+
+test('classifyLine: h3 with inline bold strips markers (regression for #21)', () => {
+  const r = classifyLine('### **Outcomes** for week');
+  assert.equal(r.type, 'h3');
+  assert.equal(r.text, 'Outcomes for week');
+  assert.deepEqual(r.ranges, [[0, 7]]);
 });
 
 test('classifyLine: bullet with inline bold preserves ranges (regression for #3)', () => {

--- a/insert-sprint.gs
+++ b/insert-sprint.gs
@@ -51,9 +51,10 @@ function insertSprintReview(fileContent) {
 
     // H1: # 19/Abr [-----]  (trailing hyphen run optional — replaced with underscores to render as a continuous line)
     if (/^# \d+\//.test(line)) {
-      let text = line.replace(/^# /, '').trim();
-      text = text.replace(/-{3,}\s*$/, '_'.repeat(20));
-      body.insertParagraph(insertPos++, text)
+      let raw = line.replace(/^# /, '').trim();
+      raw = raw.replace(/-{3,}\s*$/, '_'.repeat(20));
+      const parsed = parseInlineBold(raw);
+      body.insertParagraph(insertPos++, parsed.text)
           .setHeading(DocumentApp.ParagraphHeading.HEADING1);
       continue;
     }
@@ -63,19 +64,20 @@ function insertSprintReview(fileContent) {
       const raw = line.replace(/^## /, '').trim();
       const match = raw.match(/^(.+?)\s+\*(.+)\*$/);
       if (match) {
-        const mainText = match[1];
-        const italicText = match[2]; // asterisks stripped by regex
-        const fullText = mainText + ' ' + italicText;
+        const parsedMain = parseInlineBold(match[1]);
+        const italicText = match[2]; // single-asterisks stripped by regex
+        const fullText = parsedMain.text + ' ' + italicText;
         const p = body.insertParagraph(insertPos++, fullText);
         p.setHeading(DocumentApp.ParagraphHeading.HEADING2);
         const t = p.editAsText();
-        const italicStart = mainText.length + 1;
+        const italicStart = parsedMain.text.length + 1;
         const italicEnd = fullText.length - 1;
         t.setItalic(italicStart, italicEnd, true);
         t.setBold(italicStart, italicEnd, false);
         t.setFontSize(italicStart, italicEnd, 12);
       } else {
-        body.insertParagraph(insertPos++, raw)
+        const parsed = parseInlineBold(raw);
+        body.insertParagraph(insertPos++, parsed.text)
             .setHeading(DocumentApp.ParagraphHeading.HEADING2);
       }
       continue;
@@ -83,8 +85,8 @@ function insertSprintReview(fileContent) {
 
     // H3: ### text
     if (line.startsWith('### ')) {
-      const text = line.replace(/^### /, '').trim();
-      body.insertParagraph(insertPos++, text)
+      const parsed = parseInlineBold(line.replace(/^### /, '').trim());
+      body.insertParagraph(insertPos++, parsed.text)
           .setHeading(DocumentApp.ParagraphHeading.HEADING3);
       continue;
     }

--- a/parser.js
+++ b/parser.js
@@ -54,22 +54,31 @@ function classifyLine(line) {
   if (line.trim() === '') return { type: 'empty' };
 
   if (/^# \d+\//.test(line)) {
-    let text = line.replace(/^# /, '').trim();
-    text = text.replace(/-{3,}\s*$/, '_'.repeat(20));
-    return { type: 'h1', text };
+    let raw = line.replace(/^# /, '').trim();
+    raw = raw.replace(/-{3,}\s*$/, '_'.repeat(20));
+    const parsed = parseInlineBold(raw);
+    return { type: 'h1', text: parsed.text, ranges: parsed.ranges };
   }
 
   if (line.startsWith('## ')) {
     const raw = line.replace(/^## /, '').trim();
     const match = raw.match(/^(.+?)\s+\*(.+)\*$/);
     if (match) {
-      return { type: 'h2', mainText: match[1], italicText: match[2] };
+      const parsedMain = parseInlineBold(match[1]);
+      return {
+        type: 'h2',
+        mainText: parsedMain.text,
+        ranges: parsedMain.ranges,
+        italicText: match[2],
+      };
     }
-    return { type: 'h2', mainText: raw };
+    const parsed = parseInlineBold(raw);
+    return { type: 'h2', mainText: parsed.text, ranges: parsed.ranges };
   }
 
   if (line.startsWith('### ')) {
-    return { type: 'h3', text: line.replace(/^### /, '').trim() };
+    const parsed = parseInlineBold(line.replace(/^### /, '').trim());
+    return { type: 'h3', text: parsed.text, ranges: parsed.ranges };
   }
 
   if (/^\*\*[^*]+\*\*$/.test(line)) {


### PR DESCRIPTION
## Summary

H1, H2 (parte `mainText`) e H3 inseriam texto cru no Google Doc, deixando marcadores `**...**` literais. Como `parseInlineBold` já existe (introduzido em #11/#17), basta rotear o texto das headings por ele.

## Behavior

- **H1 / H3**: pares `**` são removidos; restante vira o texto da heading.
- **H2 com itálico de período** (`## Foo *(period)*`): `mainText` passa por `parseInlineBold`; a posição do itálico é recalculada com base no comprimento *após* strip.
- Estilo da heading inalterado — bold-on-bold é no-op visual, então não aplicamos `setBold(range, true)`, só removemos os marcadores.

`parser.js` retorna `ranges` no descritor (forward compat — um renderer que queira aplicar bold faixa-por-faixa tem o que precisa). `insert-sprint.gs` ignora `ranges` em headings.

## Tests

- 4 casos novos: H1 com bold após a data, H2 com bold em `mainText` (com e sem `italicText`), H3 com bold.
- Testes H1/H2/H3 existentes passam a assertar `ranges` (vazio quando não há marcadores).
- 38/38 passando localmente.

## Limitação consciente

A regex de H1 (`/^# \d+\//`) exige dígito imediatamente após `# `, então `# **19/Abr**` (data dentro do bold) cai para parágrafo. O case realista do template é `# 19/Abr ...` com bold em outras partes. Não relaxei a regex para preservar o filtro de "só sprint headings viram H1" (ver #6).

Fixes #21

---
_Generated by [Claude Code](https://claude.ai/code/session_01JeDEMt3QKappRVbLLUY9PE)_