### PR TITLE
Fix #19: build.js auto-generates parseInlineBold in insert-sprint.gs from parser.js

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ jobs:
           node --check find-script-id.js
           node --check test-script.js
           node --check parser.js
+          node --check build.js
+
+      - name: Verify insert-sprint.gs is in sync with parser.js
+        run: npm run check-sync
 
       - name: Run tests
         run: npm test

--- a/build.js
+++ b/build.js
@@ -1,0 +1,99 @@
+// Regenerates the auto-generated regions of insert-sprint.gs from parser.js.
+//
+// Apps Script does not import Node modules, so insert-sprint.gs needs its own
+// copy of any pure parser helper that runs server-side. This script keeps that
+// copy in sync: it reads named functions from parser.js (stripping the
+// module.exports line) and replaces the region between the BEGIN/END markers
+// in insert-sprint.gs.
+//
+// Usage:
+//   node build.js          → rewrite insert-sprint.gs in place if it drifted
+//   node build.js --check  → exit 1 if it would change anything (CI guard)
+
+const fs = require('fs');
+const path = require('path');
+
+const PARSER_PATH = path.join(__dirname, 'parser.js');
+const TARGET_PATH = path.join(__dirname, 'insert-sprint.gs');
+const FUNCTIONS_TO_INLINE = ['parseInlineBold'];
+
+const BEGIN_MARKER = '// ===== BEGIN auto-generated from parser.js =====';
+const END_MARKER = '// ===== END auto-generated from parser.js =====';
+
+function extractFunction(source, name) {
+  const sig = `function ${name}(`;
+  const sigIdx = source.indexOf(sig);
+  if (sigIdx === -1) {
+    throw new Error(`Function "${name}" not found in parser.js`);
+  }
+  // Walk back over a contiguous block of "//" line comments (the doc block).
+  let commentStart = sigIdx;
+  let cursor = sigIdx - 1;
+  while (cursor >= 0) {
+    const lineEnd = cursor;
+    while (cursor >= 0 && source[cursor] !== '\n') cursor--;
+    const line = source.slice(cursor + 1, lineEnd + 1);
+    if (line.trim().startsWith('//')) {
+      commentStart = cursor + 1;
+      cursor--;
+    } else {
+      break;
+    }
+  }
+  // Walk forward to find the matching closing brace.
+  let braceOpen = source.indexOf('{', sigIdx);
+  let depth = 1;
+  let i = braceOpen + 1;
+  while (i < source.length && depth > 0) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') depth--;
+    i++;
+  }
+  if (depth !== 0) {
+    throw new Error(`Unbalanced braces in function "${name}"`);
+  }
+  return source.slice(commentStart, i);
+}
+
+function build({ check }) {
+  const parser = fs.readFileSync(PARSER_PATH, 'utf8');
+  const target = fs.readFileSync(TARGET_PATH, 'utf8');
+
+  const beginIdx = target.indexOf(BEGIN_MARKER);
+  const endIdx = target.indexOf(END_MARKER);
+  if (beginIdx === -1 || endIdx === -1 || endIdx < beginIdx) {
+    throw new Error(
+      `Markers not found in ${TARGET_PATH}. Expected:\n  ${BEGIN_MARKER}\n  ${END_MARKER}`
+    );
+  }
+
+  const blocks = FUNCTIONS_TO_INLINE.map((name) => extractFunction(parser, name));
+  const generated = blocks.join('\n\n');
+  const replacement =
+    `${BEGIN_MARKER}\n` +
+    `// Do not edit by hand — run "npm run build" to regenerate from parser.js.\n` +
+    `${generated}\n` +
+    `${END_MARKER}`;
+
+  const updated =
+    target.slice(0, beginIdx) +
+    replacement +
+    target.slice(endIdx + END_MARKER.length);
+
+  if (updated === target) {
+    console.log(`${path.basename(TARGET_PATH)} is in sync with parser.js.`);
+    return;
+  }
+
+  if (check) {
+    console.error(
+      `${path.basename(TARGET_PATH)} is OUT OF SYNC with parser.js. Run "npm run build".`
+    );
+    process.exit(1);
+  }
+
+  fs.writeFileSync(TARGET_PATH, updated);
+  console.log(`Updated ${path.basename(TARGET_PATH)}.`);
+}
+
+build({ check: process.argv.includes('--check') });

--- a/insert-sprint.gs
+++ b/insert-sprint.gs
@@ -1,7 +1,7 @@
-// Apps Script entry point. The pure parsing helpers (parseInlineBold,
-// stripBold, and the regex-based dispatching) are duplicated in parser.js at
-// the repo root — that file is what the Node test suite (__tests__/parser.test.js)
-// runs against. Keep the two in sync when editing either.
+// Apps Script entry point. The pure parsing helpers live in parser.js (the
+// Node test suite in __tests__/parser.test.js runs against them). Functions
+// that need to run inside Apps Script are inlined into the auto-generated
+// region below by `npm run build` — edit them in parser.js, never here.
 
 function insertSprintReview(fileContent) {
   const DOC_ID = PropertiesService.getScriptProperties().getProperty('DOC_ID');
@@ -133,9 +133,8 @@ function insertSprintReview(fileContent) {
   Logger.log('Sprint review inserted successfully!');
 }
 
-// Returns { text, ranges } where text has **...** markers removed and
-// ranges is an array of [startIndex, endIndex] (both inclusive) pointing at
-// the positions of the originally bold runs in the stripped text.
+// ===== BEGIN auto-generated from parser.js =====
+// Do not edit by hand — run "npm run build" to regenerate from parser.js.
 function parseInlineBold(raw) {
   const ranges = [];
   let text = '';
@@ -159,8 +158,9 @@ function parseInlineBold(raw) {
       i++;
     }
   }
-  return { text: text, ranges: ranges };
+  return { text, ranges };
 }
+// ===== END auto-generated from parser.js =====
 
 function applyBoldRanges(element, ranges) {
   const t = element.editAsText();

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "main": "upload-sprint.js",
   "scripts": {
     "upload": "node upload-sprint.js",
+    "build": "node build.js",
+    "check-sync": "node build.js --check",
     "test": "node --test __tests__/parser.test.js"
   },
   "engines": {


### PR DESCRIPTION
## Summary

`parseInlineBold` era a única função genuinamente duplicada entre `parser.js` e `insert-sprint.gs`. Risco real de drift — a cópia em `.gs` podia divergir da versão testada em Node sem ninguém notar.

## Approach

Foi pelo caminho mais leve da issue: script de concatenação, não `clasp`.

- `build.js` extrai a função (com seu doc comment) de `parser.js` e substitui a região entre marcadores `BEGIN/END` em `insert-sprint.gs`.
- `npm run build` regenera `insert-sprint.gs` em place.
- `npm run check-sync` (`build.js --check`) sai com código 1 se algo mudaria — usado como CI guard.

CI ganha um step "Verify insert-sprint.gs is in sync" que falha o build se alguém editar `parser.js` sem rodar `npm run build`.

## Por quê não clasp

Clasp adicionaria CLI, credenciais separadas, e mudaria o fluxo de deploy (hoje copy-paste manual via UI do Apps Script). Para a única função realmente duplicada, foi excessivo.

## Test plan

- [x] `node build.js` regenera idempotente (in-sync após primeira execução).
- [x] `node build.js --check` sai 0 quando in-sync, 1 quando há drift (testado removendo um pedaço do parser.js).
- [x] `npm test` continua passando 38/38.
- [ ] Apps Script consegue parsear o output (sem `module.exports`, sem requires) — `parseInlineBold` agora termina com `return { text, ranges }` (shorthand), funcional em Apps Script V8.

Fixes #19

---
_Generated by [Claude Code](https://claude.ai/code/session_01JeDEMt3QKappRVbLLUY9PE)_