### PR TITLE
Fix #5: rename APPS_SCRIPT_DEPLOY_ID to APPS_SCRIPT_ID and clarify SETUP.md

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-APPS_SCRIPT_DEPLOY_ID=your-deployment-id-here
+APPS_SCRIPT_ID=your-script-id-here

--- a/SETUP.md
+++ b/SETUP.md
@@ -33,10 +33,13 @@ npm install
 ```
 
 ### Step 3: Deploy Apps Script as API Executable
+
+The Apps Script API requires the project to have at least one deployment, even when invoked with `devMode: true`.
+
 1. Open your Google Apps Script project (where `insert-sprint.gs` is deployed)
 2. Click **Deploy** → **New deployment**
 3. Type: **API Executable**
-4. Copy the **Deployment ID**
+4. Save the deployment
 
 ### Step 4: Set DOC_ID in Script Properties
 1. In Apps Script editor → **Tools** → **Script properties**
@@ -47,7 +50,11 @@ npm install
 
 ### Step 5: Configure .env
 
-Copy `.env.example` to `.env` and fill in your deployment ID:
+You need the Apps Script project's **Script ID** (not the Deployment ID).
+
+To find it: in the Apps Script editor → gear icon (**Project Settings**) → **IDs** → copy "Script ID". You can also read it off the script URL: `https://script.google.com/d/<SCRIPT_ID>/edit`.
+
+Copy `.env.example` to `.env` and fill in:
 
 ```bash
 cp .env.example .env
@@ -55,8 +62,10 @@ cp .env.example .env
 
 Edit `.env`:
 ```
-APPS_SCRIPT_DEPLOY_ID=your-deployment-id-here
+APPS_SCRIPT_ID=your-script-id-here
 ```
+
+> **Migrating from `APPS_SCRIPT_DEPLOY_ID`:** if your existing `.env` uses the older variable name, just rename the key to `APPS_SCRIPT_ID`. The value (Script ID) is the same — earlier docs misnamed it as "Deployment ID", but `script.scripts.run` and `script.projects.get` always required the Script ID. See issue #5.
 
 ### Step 6: Run the Workflow
 
@@ -86,7 +95,7 @@ On first run, a browser window will open for Google authentication.
 |------|---------|
 | `upload-sprint.js` | Node.js script — reads file and calls Apps Script |
 | `insert-sprint.gs` | Google Apps Script — formats and inserts into Google Doc |
-| `.env` | Local config (deployment ID) — not committed |
+| `.env` | Local config (`APPS_SCRIPT_ID`) — not committed |
 | `.env.example` | Template for `.env` |
 | `credentials.json` | OAuth 2.0 credentials (create via Google Cloud Console) — not committed |
 | `token.json` | Auto-generated after first auth — not committed |

--- a/test-script.js
+++ b/test-script.js
@@ -3,7 +3,7 @@ const { google } = require('googleapis');
 const { authenticate } = require('@google-cloud/local-auth');
 const path = require('path');
 
-const SCRIPT_ID = process.env.APPS_SCRIPT_DEPLOY_ID;
+const SCRIPT_ID = process.env.APPS_SCRIPT_ID;
 
 async function main() {
   const auth = await authenticate({

--- a/upload-sprint.js
+++ b/upload-sprint.js
@@ -13,7 +13,7 @@ const SCOPES = [
 const CREDENTIALS_PATH = path.join(__dirname, 'credentials.json');
 const TOKEN_PATH = path.join(__dirname, 'token.json');
 const SPRINT_FILE_PATH = path.join(__dirname, '.sprints', 'sprint-wip.md');
-const DEPLOY_ID = process.env.APPS_SCRIPT_DEPLOY_ID;
+const SCRIPT_ID = process.env.APPS_SCRIPT_ID;
 
 async function loadSavedCredentials() {
   try {
@@ -55,14 +55,14 @@ async function authorize() {
 }
 
 async function triggerAppsScript(auth, fileContent) {
-  if (!DEPLOY_ID) {
-    throw new Error('APPS_SCRIPT_DEPLOY_ID not set in .env');
+  if (!SCRIPT_ID) {
+    throw new Error('APPS_SCRIPT_ID not set in .env (see SETUP.md)');
   }
 
   const script = google.script({ version: 'v1', auth });
 
   const response = await script.scripts.run({
-    scriptId: DEPLOY_ID,
+    scriptId: SCRIPT_ID,
     requestBody: {
       function: 'insertSprintReview',
       parameters: [fileContent],


### PR DESCRIPTION
## Summary

`script.scripts.run` e `script.projects.get` da Apps Script API exigem **Script ID** (Drive file ID do projeto), não Deployment ID. O nome do env var (`APPS_SCRIPT_DEPLOY_ID`) e o `SETUP.md` step 3 ("Copy the Deployment ID") sugeriam o contrário — quem seguisse os docs ao pé da letra colocaria um Deployment ID no `.env` e as chamadas falhariam.

Como o `upload-sprint.js` funciona para o autor, o valor que está hoje no `.env` já é o Script ID — só o nome estava enganoso. Esta PR torna a nomenclatura honesta.

## Changes

- `.env.example`: renomeia para `APPS_SCRIPT_ID`
- `upload-sprint.js`: lê `APPS_SCRIPT_ID`, mensagem de erro atualizada
- `test-script.js`: lê `APPS_SCRIPT_ID`
- `SETUP.md` Step 3: remove a instrução "Copy the Deployment ID" (basta salvar a deploy)
- `SETUP.md` Step 5: instrui copiar o Script ID de **Project Settings**, com bloco de migração para quem já tinha `APPS_SCRIPT_DEPLOY_ID`

## Migração necessária

Quem já tem `.env` configurado precisa renomear a chave de `APPS_SCRIPT_DEPLOY_ID` para `APPS_SCRIPT_ID`. **O valor (Script ID) é o mesmo.** Bloco com instrução está em SETUP.md Step 5.

## Test plan

- [x] `npm test` 50/50.
- [x] `npm run check-sync` confirma `.gs` em sync.
- [x] `node --check` passa em `upload-sprint.js` e `test-script.js`.
- [ ] Após renomear sua var de ambiente: rodar `node upload-sprint.js` e confirmar que ainda funciona (tem que funcionar — só mudou o nome lido).

Fixes #5

---
_Generated by [Claude Code](https://claude.ai/code/session_01JeDEMt3QKappRVbLLUY9PE)_