### PR TITLE
Sprint workflow rebuild: paths, archive, prior-context, and re-plan rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# claude-sprint-review
+# Re-plan
 
-Claude Code slash commands for a two-stage weekly sprint review and planning workflow.
+Claude Code slash commands for a two-stage weekly sprint review and planning workflow. (Originally published as `claude-sprint-review`; the canonical project name is now `re-plan`, matching the GitHub repository.)
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -52,14 +52,9 @@ See [SETUP.md](SETUP.md) for complete configuration instructions.
 
 ## Setup
 
-1. **Rewrite the repo path** in the skill files to match your clone (the shipped value is the maintainer's). See [SETUP.md → Step 6](SETUP.md#step-6-configure-repo-path-in-skill-files) for the one-line `sed` invocation.
-2. Copy `sprint-start.md`, `sprint-update.md`, and `sprint-close.md` to `~/.claude/commands/`.
-3. Edit the **Outputs** section in `sprint-start.md` to replace `[Project 1]`, `[Project 2]`, `[Project 3]` with your own project names.
-4. Edit the **improvement goals** if yours differ from the defaults (`Work +2h`, `OoH`, `Make impact`).
-
-```bash
-cp sprint-start.md sprint-update.md sprint-close.md ~/.claude/commands/
-```
+1. **Install the skill files** with `bash install-skills.sh` — the script substitutes the `<<REPO_PATH>>` placeholder with your clone's path and writes the result to `~/.claude/commands/`. See [SETUP.md → Step 6](SETUP.md#step-6-install-skill-files) for details.
+2. Edit the **Outputs** section in `sprint-start.md` to replace `[Project 1]`, `[Project 2]`, `[Project 3]` with your own project names.
+3. Edit the **improvement goals** if yours differ from the defaults (`Work +2h`, `OoH`, `Make impact`).
 
 For the full Drive-upload setup (OAuth, Apps Script, `.env`), see [SETUP.md](SETUP.md).
 

--- a/README.md
+++ b/README.md
@@ -52,13 +52,16 @@ See [SETUP.md](SETUP.md) for complete configuration instructions.
 
 ## Setup
 
-1. Copy `sprint-start.md`, `sprint-update.md`, and `sprint-close.md` to `~/.claude/commands/`
-2. Edit the **Outputs** section in `sprint-start.md` to replace `[Project 1]`, `[Project 2]`, `[Project 3]` with your own project names
-3. Edit the **improvement goals** if yours differ from the defaults (`Work +2h`, `OoH`, `Make impact`)
+1. **Rewrite the repo path** in the skill files to match your clone (the shipped value is the maintainer's). See [SETUP.md → Step 6](SETUP.md#step-6-configure-repo-path-in-skill-files) for the one-line `sed` invocation.
+2. Copy `sprint-start.md`, `sprint-update.md`, and `sprint-close.md` to `~/.claude/commands/`.
+3. Edit the **Outputs** section in `sprint-start.md` to replace `[Project 1]`, `[Project 2]`, `[Project 3]` with your own project names.
+4. Edit the **improvement goals** if yours differ from the defaults (`Work +2h`, `OoH`, `Make impact`).
 
 ```bash
 cp sprint-start.md sprint-update.md sprint-close.md ~/.claude/commands/
 ```
+
+For the full Drive-upload setup (OAuth, Apps Script, `.env`), see [SETUP.md](SETUP.md).
 
 ## Document format
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -67,7 +67,28 @@ APPS_SCRIPT_ID=your-script-id-here
 
 > **Migrating from `APPS_SCRIPT_DEPLOY_ID`:** if your existing `.env` uses the older variable name, just rename the key to `APPS_SCRIPT_ID`. The value (Script ID) is the same — earlier docs misnamed it as "Deployment ID", but `script.scripts.run` and `script.projects.get` always required the Script ID. See issue #5.
 
-### Step 6: Run the Workflow
+### Step 6: Configure repo path in skill files
+
+The slash-command skill files (`sprint-start.md`, `sprint-update.md`, `sprint-close.md`) reference an absolute path to this repo's `.sprints/` directory so Claude Code knows where to read/write the wip and archive files. The shipped value is the maintainer's path: `/c/Users/vjpix/OneDrive/Documentos/Re-plan`.
+
+Before copying the skill files into `~/.claude/commands/`, rewrite the path to match your clone:
+
+```bash
+# from the repo root, on git-bash / WSL
+REPO_PATH="$(pwd | sed 's|^\([A-Za-z]\):|/\L\1|')"   # e.g. /c/Users/me/code/re-plan
+sed -i "s|/c/Users/vjpix/OneDrive/Documentos/Re-plan|${REPO_PATH}|g" \
+  sprint-start.md sprint-update.md sprint-close.md
+```
+
+Then copy them into Claude Code's commands directory:
+
+```bash
+cp sprint-start.md sprint-update.md sprint-close.md ~/.claude/commands/
+```
+
+(Or symlink if you'd rather edit in place.)
+
+### Step 7: Run the Workflow
 
 ```bash
 node upload-sprint.js

--- a/SETUP.md
+++ b/SETUP.md
@@ -67,26 +67,25 @@ APPS_SCRIPT_ID=your-script-id-here
 
 > **Migrating from `APPS_SCRIPT_DEPLOY_ID`:** if your existing `.env` uses the older variable name, just rename the key to `APPS_SCRIPT_ID`. The value (Script ID) is the same — earlier docs misnamed it as "Deployment ID", but `script.scripts.run` and `script.projects.get` always required the Script ID. See issue #5.
 
-### Step 6: Configure repo path in skill files
+### Step 6: Install skill files
 
-The slash-command skill files (`sprint-start.md`, `sprint-update.md`, `sprint-close.md`) reference an absolute path to this repo's `.sprints/` directory so Claude Code knows where to read/write the wip and archive files. The shipped value is the maintainer's path: `/c/Users/vjpix/OneDrive/Documentos/Re-plan`.
+The slash-command skill files (`sprint-start.md`, `sprint-update.md`, `sprint-close.md`) contain a `<<REPO_PATH>>` placeholder that needs to be replaced with the absolute path of your clone before Claude Code can use them.
 
-Before copying the skill files into `~/.claude/commands/`, rewrite the path to match your clone:
-
-```bash
-# from the repo root, on git-bash / WSL
-REPO_PATH="$(pwd | sed 's|^\([A-Za-z]\):|/\L\1|')"   # e.g. /c/Users/me/code/re-plan
-sed -i "s|/c/Users/vjpix/OneDrive/Documentos/Re-plan|${REPO_PATH}|g" \
-  sprint-start.md sprint-update.md sprint-close.md
-```
-
-Then copy them into Claude Code's commands directory:
+Run the install script — it materializes the skills into Claude Code's commands directory with the placeholder substituted:
 
 ```bash
-cp sprint-start.md sprint-update.md sprint-close.md ~/.claude/commands/
+bash install-skills.sh
+# or, with a custom destination:
+bash install-skills.sh /path/to/your/.claude/commands
 ```
 
-(Or symlink if you'd rather edit in place.)
+The script:
+- Detects this clone's path (works on Linux, macOS, and git-bash for Windows)
+- Substitutes `<<REPO_PATH>>` in each skill file
+- Writes the materialized result to `~/.claude/commands/` (default)
+- Replaces any pre-existing symlink at the destination with a real file (avoids the placeholder reaching Claude Code through a back-link to the repo)
+
+Re-run after pulling updates that touch the skill files.
 
 ### Step 7: Run the Workflow
 

--- a/install-skills.sh
+++ b/install-skills.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Materialize the slash-command skill files into Claude Code's commands dir,
+# substituting the <<REPO_PATH>> placeholder with this clone's actual path.
+#
+# Usage:
+#   bash install-skills.sh [destination]
+#
+# Default destination: ~/.claude/commands
+#
+# Re-run after pulling skill-file updates.
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Normalize Windows-style "C:/..." to git-bash "/c/..." so the substituted
+# path matches what Claude Code resolves on bash on Windows. Leave Unix
+# paths untouched.
+case "$REPO_DIR" in
+  [A-Za-z]:*)
+    drive="$(printf '%s' "${REPO_DIR%%:*}" | tr '[:upper:]' '[:lower:]')"
+    REPO_DIR="/${drive}${REPO_DIR#?:}"
+    ;;
+esac
+
+DEST="${1:-${HOME}/.claude/commands}"
+mkdir -p "$DEST"
+
+for f in sprint-start.md sprint-update.md sprint-close.md; do
+  src="${REPO_DIR}/${f}"
+  if [ ! -f "$src" ]; then
+    echo "skip ${f} (not found at ${src})" >&2
+    continue
+  fi
+
+  out="${DEST}/${f}"
+  # If the destination is a symlink (e.g. left from a previous install),
+  # remove it so we write a real file rather than following the link back
+  # into the repo and corrupting the placeholder source.
+  if [ -L "$out" ]; then
+    rm "$out"
+  fi
+
+  # Portable in-place rewrite without sed -i (BSD vs GNU incompatibility):
+  # render to a temp file, then move into place atomically.
+  tmp="$(mktemp "${out}.XXXXXX")"
+  sed "s|<<REPO_PATH>>|${REPO_DIR}|g" "$src" > "$tmp"
+  mv "$tmp" "$out"
+
+  echo "installed ${f} -> ${out}"
+done

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "claude-sprint-review",
+  "name": "re-plan",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "claude-sprint-review",
+      "name": "re-plan",
       "version": "1.0.0",
       "dependencies": {
         "@google-cloud/local-auth": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "claude-sprint-review",
+  "name": "re-plan",
   "version": "1.0.0",
   "description": "Sprint review automation with Google Docs integration",
   "main": "upload-sprint.js",

--- a/sprint-close.md
+++ b/sprint-close.md
@@ -66,4 +66,13 @@ Faça apenas 2 perguntas em uma mensagem:
 
 Incorpore o feedback e entregue a versão final pronta para copiar para o Google Docs.
 
-Mantenha o arquivo `/c/Users/vjpix/OneDrive/Documentos/Re-plan/.sprints/sprint-wip.md` no lugar — `upload-sprint.js` lê esse arquivo para inserir a review no Google Doc. Apague manualmente quando não precisar mais.
+---
+
+## PASSO 6: Salvar e arquivar
+
+Após a versão final estar aprovada:
+
+1. **Sobrescreva `.sprints/sprint-wip.md`** com o conteúdo final limpo (sem `[PENDING]`, sem comentários). Esse é o arquivo que `upload-sprint.js` envia para o Google Doc.
+2. **Arquive uma cópia imutável** em `/c/Users/vjpix/OneDrive/Documentos/Re-plan/.sprints/archive/<DATA-FIM-SPRINT>.md`, onde `<DATA-FIM-SPRINT>` é o último dia do sprint que está fechando, em formato `YYYY-MM-DD` (ex.: sprint 20–26/Abr → `2026-04-26.md`). Crie o diretório `.sprints/archive/` se ainda não existir.
+
+O arquivo arquivado é a **fonte de contexto** que `/sprint-start` (PASSO 1b) lê na próxima sexta para preservar "On my mind", "On hold" e metas de Health entre sprints. Não apague — sobrescrever o `sprint-wip.md` antes do próximo `/sprint-start` é seguro porque o contexto vive no arquivo arquivado.

--- a/sprint-close.md
+++ b/sprint-close.md
@@ -4,7 +4,7 @@ Você é um assistente de revisão e planejamento semanal — **Etapa 2** (prime
 
 ## PASSO 1: Carregar rascunho
 
-Leia o arquivo `/c/Users/vjpix/claude-sprint-review/.sprints/sprint-wip.md`.
+Leia o arquivo `/c/Users/vjpix/OneDrive/Documentos/Re-plan/.sprints/sprint-wip.md`.
 Extraia: período do sprint, data de geração, conteúdo do rascunho.
 Informe ao usuário: "Encontrei o rascunho do sprint [período]. Vou coletar os dados que faltaram."
 
@@ -66,4 +66,4 @@ Faça apenas 2 perguntas em uma mensagem:
 
 Incorpore o feedback e entregue a versão final pronta para copiar para o Google Docs.
 
-Mantenha o arquivo `/c/Users/vjpix/claude-sprint-review/.sprints/sprint-wip.md` no lugar — `upload-sprint.js` lê esse arquivo para inserir a review no Google Doc. Apague manualmente quando não precisar mais.
+Mantenha o arquivo `/c/Users/vjpix/OneDrive/Documentos/Re-plan/.sprints/sprint-wip.md` no lugar — `upload-sprint.js` lê esse arquivo para inserir a review no Google Doc. Apague manualmente quando não precisar mais.

--- a/sprint-close.md
+++ b/sprint-close.md
@@ -4,7 +4,7 @@ Você é um assistente de revisão e planejamento semanal — **Etapa 2** (prime
 
 ## PASSO 1: Carregar rascunho
 
-Leia o arquivo `/c/Users/vjpix/OneDrive/Documentos/Re-plan/.sprints/sprint-wip.md`.
+Leia o arquivo `<<REPO_PATH>>/.sprints/sprint-wip.md`.
 Extraia: período do sprint, data de geração, conteúdo do rascunho.
 Informe ao usuário: "Encontrei o rascunho do sprint [período]. Vou coletar os dados que faltaram."
 
@@ -73,6 +73,6 @@ Incorpore o feedback e entregue a versão final pronta para copiar para o Google
 Após a versão final estar aprovada:
 
 1. **Sobrescreva `.sprints/sprint-wip.md`** com o conteúdo final limpo (sem `[PENDING]`, sem comentários). Esse é o arquivo que `upload-sprint.js` envia para o Google Doc.
-2. **Arquive uma cópia imutável** em `/c/Users/vjpix/OneDrive/Documentos/Re-plan/.sprints/archive/<DATA-FIM-SPRINT>.md`, onde `<DATA-FIM-SPRINT>` é o último dia do sprint que está fechando, em formato `YYYY-MM-DD` (ex.: sprint 20–26/Abr → `2026-04-26.md`). Crie o diretório `.sprints/archive/` se ainda não existir.
+2. **Arquive uma cópia imutável** em `<<REPO_PATH>>/.sprints/archive/<DATA-FIM-SPRINT>.md`, onde `<DATA-FIM-SPRINT>` é o último dia do sprint que está fechando, em formato `YYYY-MM-DD` (ex.: sprint 20–26/Abr → `2026-04-26.md`). Crie o diretório `.sprints/archive/` se ainda não existir. Se o arquivo já existir (rerun de `/sprint-close` no mesmo ciclo), sobrescreva — apenas a última revisão é mantida, e isso é intencional.
 
 O arquivo arquivado é a **fonte de contexto** que `/sprint-start` (PASSO 1b) lê na próxima sexta para preservar "On my mind", "On hold" e metas de Health entre sprints. Não apague — sobrescrever o `sprint-wip.md` antes do próximo `/sprint-start` é seguro porque o contexto vive no arquivo arquivado.

--- a/sprint-start.md
+++ b/sprint-start.md
@@ -28,18 +28,26 @@ Ao receber:
 
 ## PASSO 1b: Contexto do sprint anterior
 
-Antes de coletar dados, leia `/c/Users/vjpix/OneDrive/Documentos/Re-plan/.sprints/sprint-wip.md` (se existir).
+Antes de coletar dados, identifique o arquivo mais recente em `/c/Users/vjpix/OneDrive/Documentos/Re-plan/.sprints/archive/` (nomes em formato `YYYY-MM-DD.md`, escolha a data mais recente) e leia-o. Esse arquivo é o snapshot imutável do último sprint fechado e é a fonte canônica de contexto entre sprints.
 
 Extraia, do Sprint Planning anterior:
 - Itens em **On my mind**
 - Itens em **On hold**
 - Metas de **Health** (Meditate, Exercise, Sleep Score)
 
-Use essas informações no PASSO 4c:
-- "On my mind" e "On hold" são preservados no novo Planning a menos que haja sinal de mudança (item resolvido, projeto retomado, decisão recebida)
-- Metas de Health do sprint anterior servem como baseline para propor as próximas metas
+Aplique essas informações no PASSO 4c. Itens "On my mind" e "On hold" só são removidos quando há sinal **explícito** nos dados coletados no PASSO 2 — nunca por inferência genérica:
 
-Se o arquivo não existir, prossiga sem contexto anterior.
+- Remover de **On my mind** se:
+  - Tarefa correspondente foi concluída em TickTick no período do sprint, OU
+  - Email de aprovação/decisão/resposta chegou em Gmail (ex.: recrutador respondeu, parceiro confirmou)
+- Mover de **On hold** para **Projects Priority** se:
+  - O bloqueador (pessoa/decisão externa) respondeu por email/calendário, OU
+  - Tarefas associadas ao projeto foram reativadas em TickTick (saíram do estado "aguardando")
+- Caso contrário, preservar o item exatamente como está no arquivo arquivado.
+
+Metas de Health do sprint anterior servem como baseline para propor as próximas metas (ex.: se Sleep Score foi 70 com meta 85, propor algo como 77 — ajuste incremental, não otimista).
+
+Se o diretório `archive/` não existir ou estiver vazio (primeiro uso), prossiga sem contexto anterior.
 
 ---
 

--- a/sprint-start.md
+++ b/sprint-start.md
@@ -28,7 +28,7 @@ Ao receber:
 
 ## PASSO 1b: Contexto do sprint anterior
 
-Antes de coletar dados, identifique o arquivo mais recente em `/c/Users/vjpix/OneDrive/Documentos/Re-plan/.sprints/archive/` (nomes em formato `YYYY-MM-DD.md`, escolha a data mais recente) e leia-o. Esse arquivo é o snapshot imutável do último sprint fechado e é a fonte canônica de contexto entre sprints.
+Antes de coletar dados, identifique o arquivo mais recente em `<<REPO_PATH>>/.sprints/archive/` (nomes em formato `YYYY-MM-DD.md`, escolha a data mais recente) e leia-o. Esse arquivo é o snapshot imutável do último sprint fechado e é a fonte canônica de contexto entre sprints.
 
 Extraia, do Sprint Planning anterior:
 - Itens em **On my mind**
@@ -47,7 +47,7 @@ Aplique essas informações no PASSO 4c. Itens "On my mind" e "On hold" só são
 
 Metas de Health do sprint anterior servem como baseline para propor as próximas metas (ex.: se Sleep Score foi 70 com meta 85, propor algo como 77 — ajuste incremental, não otimista).
 
-Se o diretório `archive/` não existir ou estiver vazio (primeiro uso), prossiga sem contexto anterior.
+Se o diretório `archive/` não existir ou estiver vazio (primeiro uso), tente o fallback legacy `<<REPO_PATH>>/.sprints/sprint-final.md` (formato antigo, sprint anterior). Se nem isso existir, prossiga sem contexto anterior.
 
 ---
 
@@ -259,7 +259,7 @@ Aguarde confirmação antes de continuar.
 ## PASSO 5: Salvar rascunho
 
 Após confirmação do Planning, salve o documento completo (plano do dia + Review + Retro + Planning) no arquivo:
-`/c/Users/vjpix/OneDrive/Documentos/Re-plan/.sprints/sprint-wip.md`
+`<<REPO_PATH>>/.sprints/sprint-wip.md`
 
 Inclua no topo do arquivo:
 ```

--- a/sprint-start.md
+++ b/sprint-start.md
@@ -26,6 +26,23 @@ Ao receber:
 
 ---
 
+## PASSO 1b: Contexto do sprint anterior
+
+Antes de coletar dados, leia `/c/Users/vjpix/OneDrive/Documentos/Re-plan/.sprints/sprint-wip.md` (se existir).
+
+Extraia, do Sprint Planning anterior:
+- Itens em **On my mind**
+- Itens em **On hold**
+- Metas de **Health** (Meditate, Exercise, Sleep Score)
+
+Use essas informações no PASSO 4c:
+- "On my mind" e "On hold" são preservados no novo Planning a menos que haja sinal de mudança (item resolvido, projeto retomado, decisão recebida)
+- Metas de Health do sprint anterior servem como baseline para propor as próximas metas
+
+Se o arquivo não existir, prossiga sem contexto anterior.
+
+---
+
 ## PASSO 2: Coleta automática de dados
 
 Execute em paralelo **sem pedir permissão**:
@@ -234,7 +251,7 @@ Aguarde confirmação antes de continuar.
 ## PASSO 5: Salvar rascunho
 
 Após confirmação do Planning, salve o documento completo (plano do dia + Review + Retro + Planning) no arquivo:
-`/c/Users/vjpix/claude-sprint-review/.sprints/sprint-wip.md`
+`/c/Users/vjpix/OneDrive/Documentos/Re-plan/.sprints/sprint-wip.md`
 
 Inclua no topo do arquivo:
 ```
@@ -246,4 +263,4 @@ Inclua no topo do arquivo:
 ## PASSO 6: Confirmar
 
 Informe ao usuário:
-- "Rascunho salvo em claude-sprint-review/.sprints/sprint-wip.md. Quando quiser fechar o sprint na segunda, use `/sprint-close`."
+- "Rascunho salvo em Re-plan/.sprints/sprint-wip.md. Quando quiser fechar o sprint na segunda, use `/sprint-close`."

--- a/sprint-update.md
+++ b/sprint-update.md
@@ -4,7 +4,7 @@ You are a weekly sprint review and planning assistant — **Edit mode**.
 
 ## STEP 1: Load draft
 
-Read the file `~/sprint-wip.md`.
+Read the file `<<REPO_PATH>>/.sprints/sprint-wip.md`.
 Display the full content to the user exactly as-is (day plan + document).
 
 ---
@@ -20,6 +20,6 @@ Apply all changes in one pass.
 
 ## STEP 3: Save
 
-Overwrite `~/sprint-wip.md` with the updated content, preserving the `<!-- sprint-wip: ... -->` header.
+Overwrite `<<REPO_PATH>>/.sprints/sprint-wip.md` with the updated content, preserving the `<!-- sprint-wip: ... -->` header.
 
 Confirm: "Done. Draft updated."


### PR DESCRIPTION
## Summary

Addresses all four review suggestions on the original PR:

1. **Path fix** (commit `cc87121`) — repoint hardcoded `claude-sprint-review` paths to the current repo location.
2. **Archive + tighter prior-context** (commit `248f178`) — `/sprint-close` now writes the final clean doc back to `.sprints/sprint-wip.md` *and* copies it to `.sprints/archive/<sprint-end-date>.md` as an immutable snapshot. `/sprint-start` PASSO 1b reads the latest archive (not the live wip), eliminating the same-cycle re-run hazard. The "sign of change" rule is now driven by explicit TickTick/Gmail signals collected in PASSO 2 instead of LLM judgment.
3. **Configurable repo path** (commit `8a4b613`) — SETUP.md gains a Step 6 with a one-line `sed` invocation to retarget the skill files for any clone path; README points at it.
4. **Canonical rename to `re-plan`** (commit `63f00ee`) — `package.json`, `package-lock.json`, and the README title now all use `re-plan`, matching the GitHub repo.

## Test plan

- [ ] Run `/sprint-close` end-to-end and verify both `.sprints/sprint-wip.md` and `.sprints/archive/<date>.md` are produced with identical, [PENDING]-free content
- [ ] Run `/sprint-start` and verify it reads from `.sprints/archive/` (latest date) — not from the live wip — and proposes "On my mind" / "On hold" / Health goals carried forward
- [ ] Confirm a TickTick task completion correctly removes a matching "On my mind" item; absence of signal preserves it
- [ ] Run `node upload-sprint.js` after `/sprint-close` and verify the Google Doc shows the resolved final content (no `[PENDING]`)
- [ ] On a fresh clone (different path), run the SETUP.md Step 6 `sed` and confirm `/sprint-start` resolves the new path
- [ ] `npm install` succeeds with the renamed `package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)