### PR TITLE
Resolve follow-up cleanups: bin/ move, CI guard, sanity check, README sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,22 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+      - name: Skill files use <<REPO_PATH>> placeholder, not hardcoded paths
+        run: |
+          # Skill files are templates: every absolute path pointing at a
+          # clone-specific location must use the <<REPO_PATH>> token.
+          # Catch obvious user-home prefixes that snuck in.
+          if grep -nE '(^|[^<])(/c/Users/|/Users/|/home/)[A-Za-z0-9_.-]+/' sprint-start.md sprint-update.md sprint-close.md; then
+            echo "::error::Skill files contain hardcoded absolute user paths. Use <<REPO_PATH>> instead."
+            exit 1
+          fi
+
+      - name: install-skills.sh produces clean output (no leftover placeholders)
+        run: |
+          dest="$(mktemp -d)"
+          bash bin/install-skills.sh "$dest"
+          if grep -l '<<REPO_PATH>>' "$dest"/*.md; then
+            echo "::error::install-skills.sh left <<REPO_PATH>> tokens in output — placeholder spelling drift?"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ See [SETUP.md](SETUP.md) for complete configuration instructions.
 
 ## Setup
 
-1. **Install the skill files** with `bash install-skills.sh` — the script substitutes the `<<REPO_PATH>>` placeholder with your clone's path and writes the result to `~/.claude/commands/`. See [SETUP.md → Step 6](SETUP.md#step-6-install-skill-files) for details.
+1. **Install the skill files** with `npm run install-skills` (or `bash bin/install-skills.sh`) — the script substitutes the `<<REPO_PATH>>` placeholder with your clone's path and writes the result to `~/.claude/commands/`. See [SETUP.md → Step 6](SETUP.md#step-6-install-skill-files) for details.
 2. Edit the **Outputs** section in `sprint-start.md` to replace `[Project 1]`, `[Project 2]`, `[Project 3]` with your own project names.
 3. Edit the **improvement goals** if yours differ from the defaults (`Work +2h`, `OoH`, `Make impact`).
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ See [SETUP.md](SETUP.md) for complete configuration instructions.
 ## Setup
 
 1. **Install the skill files** with `npm run install-skills` (or `bash bin/install-skills.sh`) — the script substitutes the `<<REPO_PATH>>` placeholder with your clone's path and writes the result to `~/.claude/commands/`. See [SETUP.md → Step 6](SETUP.md#step-6-install-skill-files) for details.
-2. Edit the **Outputs** section in `sprint-start.md` to replace `[Project 1]`, `[Project 2]`, `[Project 3]` with your own project names.
-3. Edit the **improvement goals** if yours differ from the defaults (`Work +2h`, `OoH`, `Make impact`).
+2. **Adapt the project list** — the shipped `sprint-start.md` PASSO 4a/4c includes the maintainer's own projects (Diar.ia, Clarice, Jandig, …) as concrete examples. Replace those project names with your own; the Outputs/Outcomes structure stays.
+3. **Adjust the improvement goals** if yours differ from the defaults (`Work +2h`, `OoH`, `Make impact`).
 
 For the full Drive-upload setup (OAuth, Apps Script, `.env`), see [SETUP.md](SETUP.md).
 
@@ -65,9 +65,9 @@ The generated document follows this structure:
 ```
 [DATE] -------------------------------------
 Sprint Review ([period], X workdays)
-Outcomes
-Outputs
-  [by project]
+  Outcomes
+  Outputs
+    [by project]
 
 Sprint Retrospective
   Last week's improvement goals (with results)
@@ -78,9 +78,10 @@ Sprint Retrospective
 
 Sprint Planning ([next period])
   Week goal
-  Priority order
-  On my mind / On hold
-  Main Outputs
+  Projects Priority
+  On my mind
+  On hold
+  Outcomes        # numbered, one per active project, "Project → result"
   Next week's goals
 ```
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -74,9 +74,9 @@ The slash-command skill files (`sprint-start.md`, `sprint-update.md`, `sprint-cl
 Run the install script — it materializes the skills into Claude Code's commands directory with the placeholder substituted:
 
 ```bash
-bash install-skills.sh
+npm run install-skills
 # or, with a custom destination:
-bash install-skills.sh /path/to/your/.claude/commands
+bash bin/install-skills.sh /path/to/your/.claude/commands
 ```
 
 The script:

--- a/bin/install-skills.sh
+++ b/bin/install-skills.sh
@@ -3,7 +3,8 @@
 # substituting the <<REPO_PATH>> placeholder with this clone's actual path.
 #
 # Usage:
-#   bash install-skills.sh [destination]
+#   bash bin/install-skills.sh [destination]
+#   npm run install-skills    # equivalent
 #
 # Default destination: ~/.claude/commands
 #
@@ -11,7 +12,8 @@
 
 set -euo pipefail
 
-REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Script lives in <repo>/bin — REPO_DIR is the parent.
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # Normalize Windows-style "C:/..." to git-bash "/c/..." so the substituted
 # path matches what Claude Code resolves on bash on Windows. Leave Unix
@@ -46,6 +48,12 @@ for f in sprint-start.md sprint-update.md sprint-close.md; do
   tmp="$(mktemp "${out}.XXXXXX")"
   sed "s|<<REPO_PATH>>|${REPO_DIR}|g" "$src" > "$tmp"
   mv "$tmp" "$out"
+
+  # Sanity check: catch typos like <<REPOPATH>> or a skill file that forgot
+  # to use the placeholder. We expect zero <<REPO_PATH>> tokens after install.
+  if grep -q '<<REPO_PATH>>' "$out"; then
+    echo "warning: ${out} still contains <<REPO_PATH>> after substitution — check the placeholder spelling in ${src}" >&2
+  fi
 
   echo "installed ${f} -> ${out}"
 done

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "upload": "node upload-sprint.js",
     "build": "node build.js",
     "check-sync": "node build.js --check",
+    "install-skills": "bash bin/install-skills.sh",
     "test": "node --test __tests__/parser.test.js __tests__/insert.test.js"
   },
   "engines": {

--- a/sprint-start.md
+++ b/sprint-start.md
@@ -271,4 +271,4 @@ Inclua no topo do arquivo:
 ## PASSO 6: Confirmar
 
 Informe ao usuário:
-- "Rascunho salvo em Re-plan/.sprints/sprint-wip.md. Quando quiser fechar o sprint na segunda, use `/sprint-close`."
+- "Rascunho salvo em `.sprints/sprint-wip.md`. Quando quiser fechar o sprint na segunda, use `/sprint-close`."


### PR DESCRIPTION
Closes #36, #37, #38, #39.

## Summary

Four small follow-ups from the post-#35 review, all independently mergeable:

* **#39** — `git mv install-skills.sh bin/install-skills.sh`; `package.json` gets an `install-skills` script so users can run `npm run install-skills`. README/SETUP updated.
* **#36** — `install-skills.sh` warns to stderr if any output file still contains `<<REPO_PATH>>` after substitution. Two new CI steps fail the build if (a) skill files reintroduce a hardcoded user-home path or (b) a fresh install leaves `<<REPO_PATH>>` tokens behind.
* **#37** — Cosmetic: dropped the literal `Re-plan/` prefix from `sprint-start.md` PASSO 6's user-facing confirmation message.
* **#38** — README's Setup step 2 and "Document format" block updated to reflect what the skills actually emit today (Projects Priority / On my mind / On hold / Outcomes — no more "Priority order" or "Main Outputs").

## Test plan

- [ ] CI passes (the new guards run against the current skill files — should be green)
- [ ] `npm run install-skills` materializes a clean `~/.claude/commands/sprint-*.md` with no `<<REPO_PATH>>` tokens
- [ ] Manually verify a deliberately broken skill file (typo `<<REPOPATH>>`) triggers the new CI failure
- [ ] README renders correctly on github.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)