### PR TITLE
Tighten CI skill guards, split into own job, link README to skill files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,21 +34,11 @@ jobs:
       - name: Run tests
         run: npm test
 
-      - name: Skill files use <<REPO_PATH>> placeholder, not hardcoded paths
-        run: |
-          # Skill files are templates: every absolute path pointing at a
-          # clone-specific location must use the <<REPO_PATH>> token.
-          # Catch obvious user-home prefixes that snuck in.
-          if grep -nE '(^|[^<])(/c/Users/|/Users/|/home/)[A-Za-z0-9_.-]+/' sprint-start.md sprint-update.md sprint-close.md; then
-            echo "::error::Skill files contain hardcoded absolute user paths. Use <<REPO_PATH>> instead."
-            exit 1
-          fi
+  skill-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
 
-      - name: install-skills.sh produces clean output (no leftover placeholders)
-        run: |
-          dest="$(mktemp -d)"
-          bash bin/install-skills.sh "$dest"
-          if grep -l '<<REPO_PATH>>' "$dest"/*.md; then
-            echo "::error::install-skills.sh left <<REPO_PATH>> tokens in output — placeholder spelling drift?"
-            exit 1
-          fi
+      # Pure shell check — no node modules needed, runs in parallel with `test`.
+      - name: Validate skill files (no hardcoded paths, clean install)
+        run: bash bin/check-skills.sh

--- a/README.md
+++ b/README.md
@@ -60,30 +60,7 @@ For the full Drive-upload setup (OAuth, Apps Script, `.env`), see [SETUP.md](SET
 
 ## Document format
 
-The generated document follows this structure:
-
-```
-[DATE] -------------------------------------
-Sprint Review ([period], X workdays)
-  Outcomes
-  Outputs
-    [by project]
-
-Sprint Retrospective
-  Last week's improvement goals (with results)
-  Health goals (with results)
-  What did I do well?
-  What could be improved?
-  What will I commit to improving?
-
-Sprint Planning ([next period])
-  Week goal
-  Projects Priority
-  On my mind
-  On hold
-  Outcomes        # numbered, one per active project, "Project → result"
-  Next week's goals
-```
+The exact structure of the generated document — Review/Retrospective/Planning sections, Outputs/Outcomes rules, table layouts — is defined by the skill files themselves. Rather than mirror it here (and risk drift), see [`sprint-start.md`](sprint-start.md) for the authoritative templates: PASSO 4a (Review), PASSO 4b (Retrospective), and PASSO 4c (Planning).
 
 ## Notes
 

--- a/__tests__/skill-checks.test.js
+++ b/__tests__/skill-checks.test.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const CHECK = path.join(REPO_ROOT, 'bin', 'check-skills.sh');
+
+function runCheck(srcDir) {
+  const args = srcDir ? [CHECK, srcDir] : [CHECK];
+  return spawnSync('bash', args, { encoding: 'utf8' });
+}
+
+function writeFixture(content) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-fixture-'));
+  fs.writeFileSync(path.join(dir, 'sprint-start.md'), content);
+  fs.writeFileSync(path.join(dir, 'sprint-update.md'), '');
+  fs.writeFileSync(path.join(dir, 'sprint-close.md'), '');
+  return dir;
+}
+
+test('check-skills.sh passes against the live skill files', () => {
+  const r = runCheck();
+  assert.equal(r.status, 0, `expected exit 0; stdout=${r.stdout} stderr=${r.stderr}`);
+});
+
+test('catches hardcoded /c/Users/ path', () => {
+  const dir = writeFixture('Read the file `/c/Users/baduser/.sprints/wip.md`.\n');
+  const r = runCheck(dir);
+  assert.equal(r.status, 1, 'expected exit 1 on hardcoded /c/Users path');
+  assert.match(r.stderr, /hardcoded absolute user paths/);
+});
+
+test('catches hardcoded /home/ path', () => {
+  const dir = writeFixture('Read `/home/alice/.sprints/wip.md`.\n');
+  const r = runCheck(dir);
+  assert.equal(r.status, 1, 'expected exit 1 on hardcoded /home path');
+});
+
+test('catches end-of-line /Users/<user> with no trailing slash', () => {
+  // Regression for the "trailing-slash gap" the reviewer flagged: a path
+  // that ends at end-of-line, no following segment, must still trip the guard.
+  const dir = writeFixture('Read /Users/jane\n');
+  const r = runCheck(dir);
+  assert.equal(r.status, 1, 'expected exit 1 on end-of-line /Users/<user>');
+});
+
+test('does not flag the documented <<REPO_PATH>> placeholder', () => {
+  const dir = writeFixture('Read `<<REPO_PATH>>/.sprints/sprint-wip.md`.\n');
+  const r = runCheck(dir);
+  assert.equal(r.status, 0, `placeholder usage must pass; stderr=${r.stderr}`);
+});
+
+test('install-skills materialization leaves no <<REPO_PATH>> tokens', () => {
+  // The "clean install" check is part of check-skills.sh's positive run,
+  // but assert it standalone to surface the failure mode clearly.
+  const dest = fs.mkdtempSync(path.join(os.tmpdir(), 'install-test-'));
+  const r = spawnSync('bash', [path.join(REPO_ROOT, 'bin', 'install-skills.sh'), dest], {
+    encoding: 'utf8'
+  });
+  assert.equal(r.status, 0, `install-skills.sh failed: ${r.stderr}`);
+  for (const f of fs.readdirSync(dest)) {
+    const body = fs.readFileSync(path.join(dest, f), 'utf8');
+    assert.doesNotMatch(body, /<<REPO_PATH>>/, `${f} still has <<REPO_PATH>>`);
+  }
+});

--- a/bin/check-skills.sh
+++ b/bin/check-skills.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Validate the slash-command skill files.
+#
+# Two checks:
+#   1. No hardcoded user-home paths in the skill files (must use <<REPO_PATH>>)
+#   2. install-skills.sh produces output free of <<REPO_PATH>> tokens
+#
+# Usage:
+#   bash bin/check-skills.sh [src-dir]
+#
+# Default src-dir is the repo root. Pass a custom dir to validate a fixture
+# (used by the unit tests in __tests__/skill-checks.test.js).
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC_DIR="${1:-$REPO_DIR}"
+
+skills=( "$SRC_DIR/sprint-start.md" "$SRC_DIR/sprint-update.md" "$SRC_DIR/sprint-close.md" )
+
+# ----------------------------------------------------------------------------
+# Check 1: skill files must not embed clone-specific user-home paths.
+#
+# The regex catches /c/Users/<user>, /Users/<user>, /home/<user> followed by
+# either a slash OR end-of-line — so it fires on both `/c/Users/foo/bar` and
+# the bare end-of-line form `/c/Users/foo`. The leading `(^|[^<])` excludes
+# matches that come from inside the documented `<<REPO_PATH>>` token.
+# ----------------------------------------------------------------------------
+HARDCODED_RE='(^|[^<])(/c/Users/|/Users/|/home/)[A-Za-z0-9_.-]+(/|$)'
+
+if grep -nE "$HARDCODED_RE" "${skills[@]}" 2>/dev/null; then
+  echo "::error::Skill files contain hardcoded absolute user paths. Use <<REPO_PATH>> instead." >&2
+  exit 1
+fi
+
+# ----------------------------------------------------------------------------
+# Check 2: a fresh install must materialize cleanly — no surviving
+# <<REPO_PATH>> tokens. install-skills.sh always reads from the repo root,
+# so this exercises the live skills regardless of SRC_DIR.
+# ----------------------------------------------------------------------------
+dest="$(mktemp -d)"
+trap 'rm -rf "$dest"' EXIT
+
+bash "$REPO_DIR/bin/install-skills.sh" "$dest" >/dev/null
+
+if grep -l '<<REPO_PATH>>' "$dest"/*.md 2>/dev/null; then
+  echo "::error::install-skills.sh left <<REPO_PATH>> tokens in output — placeholder spelling drift?" >&2
+  exit 1
+fi
+
+echo "Skill checks passed."

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "node build.js",
     "check-sync": "node build.js --check",
     "install-skills": "bash bin/install-skills.sh",
-    "test": "node --test __tests__/parser.test.js __tests__/insert.test.js"
+    "check-skills": "bash bin/check-skills.sh",
+    "test": "node --test __tests__/parser.test.js __tests__/insert.test.js __tests__/skill-checks.test.js"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
Resolves all four follow-ups from the post-#40 review.

## Summary

* **#1 (negative test)** — `__tests__/skill-checks.test.js` exercises the guard with both passing fixtures (current skill files, `<<REPO_PATH>>` placeholder usage) and failing fixtures (`/c/Users/<user>/...`, `/home/<user>/...`, end-of-line `/Users/<user>`). 6 new tests, all green locally.
* **#2 (tighter regex)** — the hardcoded-path pattern's trailing `/` is now optional, so `/c/Users/foo` at end-of-line is caught. Pattern: `(^|[^<])(/c/Users/|/Users/|/home/)[A-Za-z0-9_.-]+(/|$)`.
* **#3 (separate CI job)** — skill validation now runs in its own `skill-checks` job, in parallel with `test`, skipping `npm ci` since it's pure shell.
* **#4 (README link)** — the hand-mirrored "Document format" block is replaced with a link to `sprint-start.md`, ending the drift cycle that just bit us with "Priority order" / "Main Outputs".

Single source of truth refactor: both CI and the local `npm run check-skills` invoke `bin/check-skills.sh`, which encodes both checks (no hardcoded paths; no surviving `<<REPO_PATH>>` after install).

## Test plan

- [ ] `npm test` passes (56 tests, includes the 6 new ones)
- [ ] `npm run check-skills` exits clean
- [ ] CI's `skill-checks` job runs in parallel with `test` and both pass
- [ ] Manually inject a `/c/Users/foo` line into a skill file (don't commit) and confirm `bash bin/check-skills.sh` exits 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)