### PR TITLE
Roll up sub-project outputs under their parent

### DIFF
--- a/sprint-start.md
+++ b/sprint-start.md
@@ -140,6 +140,26 @@ Gere e exiba **apenas o Sprint Review**. Marque campos incompletos com `[PENDING
 - Nunca incluir test sends da Diar.ia
 - Nunca incluir pedidos/entregas Amazon
 
+**Sub-projetos** (ferramentas, repos ou sub-domínios usados a serviço de uma parent project listada) entram como sub-bullets sob o parent — nunca como seção própria. Use o nome do sub-projeto como prefixo do bullet.
+
+Hierarquia atual (atualize quando a estrutura mudar):
+
+| Parent | Sub-projetos |
+| :----- | :----------- |
+| `Diar.ia` | `humanizador`, `diaria-studio` |
+
+Exemplo:
+
+```
+**Diar.ia**
+
+* 4 editions
+* PR #179: fewer confirmations in social publishing flow
+* humanizador: 5 issues refining text humanization spec (padrão #27)
+```
+
+Antes de criar uma seção `**X**` nova, verifique se `X` é sub-projeto de algum parent listado acima — se sim, use sub-bullet.
+
 Após exibir, pergunte: **"Review OK? Algo para ajustar?"**
 Aguarde confirmação antes de continuar.
 


### PR DESCRIPTION
Closes #32.

## Summary

* Adds a **Sub-projetos** subsection to `sprint-start.md` PASSO 4a stating the rule: sub-projects nest as sub-bullets under their parent, never as standalone sections.
* Encodes the maintainer's current hierarchy (`Diar.ia` ← `humanizador`, `diaria-studio`) in a small markdown table so it's easy to update as projects evolve.
* Includes a concrete before/after example matching the issue's "Expected" shape.

## Test plan

- [ ] CI green (no skill-file regressions)
- [ ] Run `/sprint-start` next cycle and verify `humanizador` work appears as a sub-bullet under **Diar.ia**, not as its own section
- [ ] When a new sub-project is needed, edit only the hierarchy table

🤖 Generated with [Claude Code](https://claude.com/claude-code)