### PR TITLE
sprint-start: infer period from today's date (closes #43)

### DIFF
--- a/sprint-start.md
+++ b/sprint-start.md
@@ -4,13 +4,14 @@ Você é um assistente de revisão e planejamento semanal — **Etapa 1** (últi
 
 ## PASSO 1: Período do sprint
 
-Pergunte: "Qual o período do sprint? (ex: 30/Mar–5/Abr)"
+**Não pergunte o período.** Infera automaticamente:
 
-Ao receber:
-- Converta para ISO 8601
-- Calcule dias úteis do sprint
-- Identifique: data de hoje é o último dia útil do sprint
+- **Início do sprint:** segunda-feira mais recente *estritamente anterior* à data de hoje. Se hoje for segunda, usar a segunda da semana anterior (sprint começou há 7 dias).
+- **Fim do sprint:** data de hoje (último dia útil do sprint).
+- Converta ambas para ISO 8601 e calcule os dias úteis do período.
 - Calcule também os dias úteis do **próximo** sprint (período seguinte de mesma duração) para uso no Sprint Planning. Ao calcular, **subtraia feriados nacionais** que caiam dentro do período. Quando houver feriado, anote-o explicitamente no header do Planning (ex.: `Sprint Planning *(27/Abr–3/Mai, 4 workdays — 1/Mai feriado)*`).
+
+O período inferido aparece no header do Sprint Review (PASSO 4a) — se estiver errado, o usuário corrige durante a revisão.
 
 **Feriados nacionais brasileiros a considerar:**
 - 1/Jan — Ano Novo

--- a/sprint-start.md
+++ b/sprint-start.md
@@ -4,14 +4,14 @@ Você é um assistente de revisão e planejamento semanal — **Etapa 1** (últi
 
 ## PASSO 1: Período do sprint
 
-**Não pergunte o período.** Infera automaticamente:
+**Não pergunte o período.** Infira automaticamente:
 
 - **Início do sprint:** segunda-feira mais recente *estritamente anterior* à data de hoje. Se hoje for segunda, usar a segunda da semana anterior (sprint começou há 7 dias).
 - **Fim do sprint:** data de hoje (último dia útil do sprint).
 - Converta ambas para ISO 8601 e calcule os dias úteis do período.
 - Calcule também os dias úteis do **próximo** sprint (período seguinte de mesma duração) para uso no Sprint Planning. Ao calcular, **subtraia feriados nacionais** que caiam dentro do período. Quando houver feriado, anote-o explicitamente no header do Planning (ex.: `Sprint Planning *(27/Abr–3/Mai, 4 workdays — 1/Mai feriado)*`).
 
-O período inferido aparece no header do Sprint Review (PASSO 4a) — se estiver errado, o usuário corrige durante a revisão.
+O período inferido aparece no header do Sprint Review (PASSO 4a) — se estiver errado, o usuário corrige durante a revisão. Se hoje não for sexta-feira (ex.: rodando mid-week por feriado ou cadência alterada), confirme com o usuário antes de prosseguir, pois o cálculo do próximo sprint usa a mesma duração e propaga o desvio.
 
 **Feriados nacionais brasileiros a considerar:**
 - 1/Jan — Ano Novo


### PR DESCRIPTION
## Summary

- Removes the manual "Qual o período do sprint?" prompt at PASSO 1.
- Sprint period is now inferred: start = last Monday strictly before today; end = today.
- Header in PASSO 4a (Sprint Review) still shows the inferred period, so the user can correct it during review if ever needed.
- Holiday-aware next-sprint computation (PASSO 4c) is unchanged.

Closes #43.

## Test plan

- [x] `npm test` passes (skill-check + AST tests).
- [ ] Run `/sprint-start` and confirm it skips straight to PASSO 1b (prior-sprint context) without asking for a period.
- [ ] Confirm the inferred period appears correctly in the Sprint Review header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)