### PR TITLE
feat: PR1/3 — TS period helpers, move date math out of skill prose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 credentials.json
 token.json
 node_modules/
+dist/
 .claude/
 .mcp.json

--- a/__tests__/period.test.ts
+++ b/__tests__/period.test.ts
@@ -90,6 +90,9 @@ test('nextPeriod: holiday within next period reduces available days, extends end
 test('nextPeriod: after Monday → next Monday is 7 days later', () => {
   const result = nextPeriod(d('2026-05-04'), 5); // Monday
   assert.equal(result.start, '2026-05-11');
+  assert.equal(result.end, '2026-05-15');
+  assert.equal(result.workdays, 5);
+  assert.deepEqual(result.holidays, []);
 });
 
 // formatPeriodHeader

--- a/__tests__/period.test.ts
+++ b/__tests__/period.test.ts
@@ -1,0 +1,120 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { inferCurrentPeriod, nextPeriod, formatPeriodHeader, toISO } from '../lib/period.js';
+
+function d(iso: string): Date {
+  const [y, m, day] = iso.split('-').map(Number);
+  return new Date(y, m - 1, day);
+}
+
+// inferCurrentPeriod
+
+test('inferCurrentPeriod: Friday → starts preceding Monday', () => {
+  const result = inferCurrentPeriod(d('2026-05-08')); // Friday
+  assert.equal(result.start, '2026-05-04');
+  assert.equal(result.end, '2026-05-08');
+  assert.equal(result.workdays, 5);
+  assert.deepEqual(result.holidays, []);
+});
+
+test('inferCurrentPeriod: Monday → starts previous Monday (7 days back)', () => {
+  const result = inferCurrentPeriod(d('2026-05-04')); // Monday
+  assert.equal(result.start, '2026-04-27');
+  assert.equal(result.end, '2026-05-04');
+  // Apr 27–May 4: Mon Apr 27, Tue 28, Wed 29, Thu 30, [May 1 holiday], Sat, Sun, Mon May 4 = 5 workdays
+  assert.equal(result.workdays, 5);
+  assert.deepEqual(result.holidays, ['2026-05-01']);
+});
+
+test('inferCurrentPeriod: week containing Dia do Trabalho (May 1)', () => {
+  const result = inferCurrentPeriod(d('2026-04-30')); // Thursday before May 1
+  assert.equal(result.start, '2026-04-27');
+  assert.equal(result.end, '2026-04-30');
+  assert.equal(result.workdays, 4);
+  assert.deepEqual(result.holidays, []);
+});
+
+test('inferCurrentPeriod: Good Friday 2026 (April 3)', () => {
+  const result = inferCurrentPeriod(d('2026-04-03')); // Friday = Good Friday
+  assert.equal(result.start, '2026-03-30');
+  assert.equal(result.end, '2026-04-03');
+  // Mon–Fri, but Fri is holiday → 4 workdays
+  assert.equal(result.workdays, 4);
+  assert.deepEqual(result.holidays, ['2026-04-03']);
+});
+
+test('inferCurrentPeriod: Good Friday 2025 (April 18)', () => {
+  const result = inferCurrentPeriod(d('2025-04-18')); // Friday = Good Friday
+  assert.equal(result.start, '2025-04-14');
+  assert.equal(result.end, '2025-04-18');
+  assert.equal(result.workdays, 4);
+  assert.deepEqual(result.holidays, ['2025-04-18']);
+});
+
+test('inferCurrentPeriod: Wednesday mid-week run', () => {
+  const result = inferCurrentPeriod(d('2026-05-06')); // Wednesday
+  assert.equal(result.start, '2026-05-04');
+  assert.equal(result.end, '2026-05-06');
+  assert.equal(result.workdays, 3);
+  assert.deepEqual(result.holidays, []);
+});
+
+// nextPeriod
+
+test('nextPeriod: after normal Friday → following Mon–Fri, no holidays', () => {
+  const result = nextPeriod(d('2026-05-08'), 5); // Friday
+  assert.equal(result.start, '2026-05-11');
+  assert.equal(result.end, '2026-05-15');
+  assert.equal(result.workdays, 5);
+  assert.deepEqual(result.holidays, []);
+});
+
+test('nextPeriod: after Apr 30 (Thu) with 4 workdays → May 4–7', () => {
+  const result = nextPeriod(d('2026-04-30'), 4);
+  assert.equal(result.start, '2026-05-04');
+  assert.equal(result.end, '2026-05-07');
+  assert.equal(result.workdays, 4);
+  assert.deepEqual(result.holidays, []);
+});
+
+test('nextPeriod: holiday within next period reduces available days, extends end', () => {
+  // Sprint ending Apr 24 (Fri) with 5 workdays → next starts Apr 27 (Mon)
+  // Apr 27–May 1 has May 1 as holiday → need to go to May 4 to get 5 workdays
+  const result = nextPeriod(d('2026-04-24'), 5);
+  assert.equal(result.start, '2026-04-27');
+  assert.equal(result.end, '2026-05-04'); // Mon Apr 27,Tue 28,Wed 29,Thu 30,[May1 hol],Sat,Sun,Mon May 4
+  assert.equal(result.workdays, 5);
+  assert.deepEqual(result.holidays, ['2026-05-01']);
+});
+
+test('nextPeriod: after Monday → next Monday is 7 days later', () => {
+  const result = nextPeriod(d('2026-05-04'), 5); // Monday
+  assert.equal(result.start, '2026-05-11');
+});
+
+// formatPeriodHeader
+
+test('formatPeriodHeader: no holidays', () => {
+  const h = formatPeriodHeader({ start: '2026-05-04', end: '2026-05-08', workdays: 5, holidays: [] });
+  assert.equal(h, '4/Mai–8/Mai, 5 workdays');
+});
+
+test('formatPeriodHeader: one holiday', () => {
+  const h = formatPeriodHeader({ start: '2026-04-27', end: '2026-05-04', workdays: 5, holidays: ['2026-05-01'] });
+  assert.equal(h, '27/Abr–4/Mai, 5 workdays — 1/Mai feriado');
+});
+
+test('formatPeriodHeader: multiple holidays', () => {
+  const h = formatPeriodHeader({
+    start: '2026-04-20', end: '2026-04-24', workdays: 3,
+    holidays: ['2026-04-21', '2026-04-22'],
+  });
+  assert.equal(h, '20/Abr–24/Abr, 3 workdays — 21/Abr, 22/Abr feriado');
+});
+
+// toISO utility
+
+test('toISO: formats date correctly', () => {
+  assert.equal(toISO(new Date(2026, 4, 1)), '2026-05-01');
+  assert.equal(toISO(new Date(2026, 0, 1)), '2026-01-01');
+});

--- a/__tests__/skill-checks.test.js
+++ b/__tests__/skill-checks.test.js
@@ -55,6 +55,25 @@ test('does not flag the documented <<REPO_PATH>> placeholder', () => {
   assert.equal(r.status, 0, `placeholder usage must pass; stderr=${r.stderr}`);
 });
 
+test('catches date-math prose: "calcule dias úteis"', () => {
+  const dir = writeFixture('- Calcule dias úteis do sprint.\n');
+  const r = runCheck(dir);
+  assert.equal(r.status, 1, 'expected exit 1 on date-math prose');
+  assert.match(r.stderr, /date-math prose/);
+});
+
+test('catches date-math prose: "Feriados nacionais brasileiros a considerar"', () => {
+  const dir = writeFixture('**Feriados nacionais brasileiros a considerar:**\n- 1/Jan\n');
+  const r = runCheck(dir);
+  assert.equal(r.status, 1, 'expected exit 1 on holiday list prose');
+});
+
+test('does not flag the sprint.ts CLI invocation line', () => {
+  const dir = writeFixture('Run `node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts period --today YYYY-MM-DD`.\n');
+  const r = runCheck(dir);
+  assert.equal(r.status, 0, `CLI invocation line must pass; stderr=${r.stderr}`);
+});
+
 test('install-skills materialization leaves no <<REPO_PATH>> tokens', () => {
   // The "clean install" check is part of check-skills.sh's positive run,
   // but assert it standalone to surface the failure mode clearly.

--- a/bin/check-skills.sh
+++ b/bin/check-skills.sh
@@ -54,7 +54,7 @@ fi
 # ----------------------------------------------------------------------------
 DATE_MATH_RE='(calcule dias úteis|última segunda|subtraia feriados|Feriados nacionais brasileiros a considerar)'
 
-if grep -nE "$DATE_MATH_RE" "${skills[@]}" 2>/dev/null; then
+if grep -nEi "$DATE_MATH_RE" "${skills[@]}" 2>/dev/null; then
   echo "::error::Skill files contain date-math prose that should live in bin/sprint.ts instead." >&2
   exit 1
 fi

--- a/bin/check-skills.sh
+++ b/bin/check-skills.sh
@@ -48,4 +48,15 @@ if grep -l '<<REPO_PATH>>' "$dest"/*.md 2>/dev/null; then
   exit 1
 fi
 
+# ----------------------------------------------------------------------------
+# Check 3: date math must not be re-embedded in skill prose.
+# These phrases signal logic that belongs in bin/sprint.ts, not in markdown.
+# ----------------------------------------------------------------------------
+DATE_MATH_RE='(calcule dias úteis|última segunda|subtraia feriados|Feriados nacionais brasileiros a considerar)'
+
+if grep -nE "$DATE_MATH_RE" "${skills[@]}" 2>/dev/null; then
+  echo "::error::Skill files contain date-math prose that should live in bin/sprint.ts instead." >&2
+  exit 1
+fi
+
 echo "Skill checks passed."

--- a/bin/install-skills.sh
+++ b/bin/install-skills.sh
@@ -28,6 +28,11 @@ esac
 DEST="${1:-${HOME}/.claude/commands}"
 mkdir -p "$DEST"
 
+# Warn if tsx is not installed — skill prose invokes it at runtime.
+if [ ! -f "$REPO_DIR/node_modules/.bin/tsx" ] && [ ! -f "$REPO_DIR/node_modules/tsx/dist/cli.mjs" ]; then
+  echo "warning: tsx not found in node_modules. Run 'npm install' before using the skills." >&2
+fi
+
 for f in sprint-start.md sprint-update.md sprint-close.md; do
   src="${REPO_DIR}/${f}"
   if [ ! -f "$src" ]; then

--- a/bin/sprint.ts
+++ b/bin/sprint.ts
@@ -9,6 +9,10 @@ function flag(args: string[], name: string): string | undefined {
 }
 
 function parseLocalDate(iso: string): Date {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(iso)) {
+    process.stderr.write(`Invalid date format: "${iso}" — expected YYYY-MM-DD\n`);
+    process.exit(1);
+  }
   const [y, m, d] = iso.split('-').map(Number);
   return new Date(y, m - 1, d);
 }

--- a/bin/sprint.ts
+++ b/bin/sprint.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import { inferCurrentPeriod, nextPeriod } from '../lib/period.js';
+
+const [, , subcommand, ...args] = process.argv;
+
+function flag(args: string[], name: string): string | undefined {
+  const i = args.indexOf(name);
+  return i !== -1 ? args[i + 1] : undefined;
+}
+
+function parseLocalDate(iso: string): Date {
+  const [y, m, d] = iso.split('-').map(Number);
+  return new Date(y, m - 1, d);
+}
+
+switch (subcommand) {
+  case 'period': {
+    const todayStr = flag(args, '--today');
+    const today = todayStr ? parseLocalDate(todayStr) : (() => {
+      const n = new Date();
+      return new Date(n.getFullYear(), n.getMonth(), n.getDate());
+    })();
+    const current = inferCurrentPeriod(today);
+    const currentEnd = parseLocalDate(current.end);
+    const next = nextPeriod(currentEnd, current.workdays);
+    process.stdout.write(JSON.stringify({ current, next }, null, 2) + '\n');
+    break;
+  }
+  default:
+    process.stderr.write(`Unknown subcommand: ${subcommand ?? '(none)'}\n`);
+    process.exit(1);
+}

--- a/lib/holidays.ts
+++ b/lib/holidays.ts
@@ -1,0 +1,44 @@
+function easterDate(year: number): Date {
+  const a = year % 19;
+  const b = Math.floor(year / 100);
+  const c = year % 100;
+  const d = Math.floor(b / 4);
+  const e = b % 4;
+  const f = Math.floor((b + 8) / 25);
+  const g = Math.floor((b - f + 1) / 3);
+  const h = (19 * a + b - d - g + 15) % 30;
+  const i = Math.floor(c / 4);
+  const k = c % 4;
+  const l = (32 + 2 * e + 2 * i - h - k) % 7;
+  const m = Math.floor((a + 11 * h + 22 * l) / 451);
+  const month = Math.floor((h + l - 7 * m + 114) / 31); // 1-based
+  const day = ((h + l - 7 * m + 114) % 31) + 1;
+  return new Date(year, month - 1, day);
+}
+
+function nationalHolidaysForYear(year: number): Date[] {
+  const easter = easterDate(year);
+  const goodFriday = new Date(easter);
+  goodFriday.setDate(goodFriday.getDate() - 2);
+
+  return [
+    new Date(year, 0, 1),   // Ano Novo
+    goodFriday,              // Sexta-feira Santa
+    new Date(year, 3, 21),  // Tiradentes
+    new Date(year, 4, 1),   // Dia do Trabalho
+    new Date(year, 8, 7),   // Independência
+    new Date(year, 9, 12),  // N.S. Aparecida
+    new Date(year, 10, 2),  // Finados
+    new Date(year, 10, 15), // Proclamação da República
+    new Date(year, 10, 20), // Consciência Negra
+    new Date(year, 11, 25), // Natal
+  ];
+}
+
+export function holidaysBetween(start: Date, end: Date): Date[] {
+  const years = new Set<number>();
+  for (let y = start.getFullYear(); y <= end.getFullYear(); y++) years.add(y);
+  return [...years]
+    .flatMap(nationalHolidaysForYear)
+    .filter(h => h >= start && h <= end);
+}

--- a/lib/period.ts
+++ b/lib/period.ts
@@ -1,0 +1,100 @@
+import { holidaysBetween } from './holidays.js';
+
+export interface Period {
+  start: string;    // YYYY-MM-DD
+  end: string;      // YYYY-MM-DD
+  workdays: number;
+  holidays: string[]; // YYYY-MM-DD — falls within start..end
+}
+
+function addDays(date: Date, n: number): Date {
+  const d = new Date(date);
+  d.setDate(d.getDate() + n);
+  return d;
+}
+
+export function toISO(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function isWeekend(date: Date): boolean {
+  const dow = date.getDay();
+  return dow === 0 || dow === 6;
+}
+
+function isHolidayDate(date: Date, holidays: Date[]): boolean {
+  const iso = toISO(date);
+  return holidays.some(h => toISO(h) === iso);
+}
+
+function isWorkday(date: Date, holidays: Date[]): boolean {
+  return !isWeekend(date) && !isHolidayDate(date, holidays);
+}
+
+function countWorkdays(start: Date, end: Date, holidays: Date[]): number {
+  let count = 0;
+  for (let d = new Date(start); d <= end; d = addDays(d, 1)) {
+    if (isWorkday(d, holidays)) count++;
+  }
+  return count;
+}
+
+export function inferCurrentPeriod(today: Date): Period {
+  const dow = today.getDay(); // 0=Sun … 6=Sat
+  // Last Monday strictly before today; if today is Monday (1), go back 7 days.
+  const daysBack = ((dow - 1 + 7) % 7) || 7;
+  const start = addDays(today, -daysBack);
+  const holidays = holidaysBetween(start, today);
+  return {
+    start: toISO(start),
+    end: toISO(today),
+    workdays: countWorkdays(start, today, holidays),
+    holidays: holidays.map(toISO),
+  };
+}
+
+export function nextPeriod(currentEnd: Date, currentWorkdays: number): Period {
+  // Next sprint always starts the following Monday.
+  const dow = currentEnd.getDay();
+  const daysToMonday = dow === 0 ? 1 : 8 - dow;
+  const start = addDays(currentEnd, daysToMonday);
+
+  // Walk forward until we've accumulated currentWorkdays workdays.
+  const upperBound = addDays(start, currentWorkdays * 3); // generous
+  const allHolidays = holidaysBetween(start, upperBound);
+  let d = new Date(start);
+  let count = 0;
+  while (count < currentWorkdays) {
+    if (isWorkday(d, allHolidays)) count++;
+    if (count < currentWorkdays) d = addDays(d, 1);
+  }
+  const end = d;
+  const periodHolidays = holidaysBetween(start, end);
+  return {
+    start: toISO(start),
+    end: toISO(end),
+    workdays: currentWorkdays,
+    holidays: periodHolidays.map(toISO),
+  };
+}
+
+const PT_MONTHS: Record<number, string> = {
+  1: 'Jan', 2: 'Fev', 3: 'Mar', 4: 'Abr', 5: 'Mai', 6: 'Jun',
+  7: 'Jul', 8: 'Ago', 9: 'Set', 10: 'Out', 11: 'Nov', 12: 'Dez',
+};
+
+function fmtDate(iso: string): string {
+  const [, m, d] = iso.split('-');
+  return `${parseInt(d)}/${PT_MONTHS[parseInt(m)]}`;
+}
+
+export function formatPeriodHeader(period: Period): string {
+  const range = `${fmtDate(period.start)}–${fmtDate(period.end)}`;
+  const days = `${period.workdays} workdays`;
+  if (period.holidays.length === 0) return `${range}, ${days}`;
+  const hols = period.holidays.map(fmtDate).join(', ');
+  return `${range}, ${days} — ${hols} feriado`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,456 @@
         "@google-cloud/local-auth": "^2.1.0",
         "dotenv": "^16.0.0",
         "googleapis": "^118.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "tsx": "^4.21.0",
+        "typescript": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@google-cloud/local-auth": {
@@ -26,6 +476,16 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/agent-base": {
@@ -195,6 +655,48 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -206,6 +708,21 @@
       "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
       "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==",
       "license": "Apache-2.0"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -279,6 +796,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/google-auth-library": {
@@ -578,6 +1108,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -680,6 +1220,47 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/url-template": {

--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
   "dependencies": {
     "@google-cloud/local-auth": "^2.1.0",
     "dotenv": "^16.0.0",
-    "googleapis": "^118.0.0"
+    "googleapis": "^118.0.0",
+    "tsx": "^4.21.0"
   },
   "devDependencies": {
     "@types/node": "^25.6.0",
-    "tsx": "^4.21.0",
     "typescript": "^6.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "check-sync": "node build.js --check",
     "install-skills": "bash bin/install-skills.sh",
     "check-skills": "bash bin/check-skills.sh",
-    "test": "node --test __tests__/parser.test.js __tests__/insert.test.js __tests__/skill-checks.test.js"
+    "test": "node --test __tests__/parser.test.js __tests__/insert.test.js __tests__/skill-checks.test.js && node -r tsx/cjs --test __tests__/period.test.ts"
   },
   "engines": {
     "node": ">=18"
@@ -18,5 +18,10 @@
     "@google-cloud/local-auth": "^2.1.0",
     "dotenv": "^16.0.0",
     "googleapis": "^118.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "tsx": "^4.21.0",
+    "typescript": "^6.0.3"
   }
 }

--- a/sprint-start.md
+++ b/sprint-start.md
@@ -4,26 +4,19 @@ Você é um assistente de revisão e planejamento semanal — **Etapa 1** (últi
 
 ## PASSO 1: Período do sprint
 
-**Não pergunte o período.** Infira automaticamente:
+Execute **sem pedir permissão**, substituindo `YYYY-MM-DD` pela data de hoje:
 
-- **Início do sprint:** segunda-feira mais recente *estritamente anterior* à data de hoje. Se hoje for segunda, usar a segunda da semana anterior (sprint começou há 7 dias).
-- **Fim do sprint:** data de hoje (último dia útil do sprint).
-- Converta ambas para ISO 8601 e calcule os dias úteis do período.
-- Calcule também os dias úteis do **próximo** sprint (período seguinte de mesma duração) para uso no Sprint Planning. Ao calcular, **subtraia feriados nacionais** que caiam dentro do período. Quando houver feriado, anote-o explicitamente no header do Planning (ex.: `Sprint Planning *(27/Abr–3/Mai, 4 workdays — 1/Mai feriado)*`).
+```bash
+node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts period --today YYYY-MM-DD
+```
 
-O período inferido aparece no header do Sprint Review (PASSO 4a) — se estiver errado, o usuário corrige durante a revisão. Se hoje não for sexta-feira (ex.: rodando mid-week por feriado ou cadência alterada), confirme com o usuário antes de prosseguir, pois o cálculo do próximo sprint usa a mesma duração e propaga o desvio.
+O JSON retornado contém dois objetos:
+- `current` — sprint atual: `start`, `end`, `workdays`, `holidays[]`
+- `next` — próximo sprint (mesma duração, feriados descontados): mesmos campos
 
-**Feriados nacionais brasileiros a considerar:**
-- 1/Jan — Ano Novo
-- Sexta-feira Santa (variável; 2 dias antes da Páscoa)
-- 21/Abr — Tiradentes
-- 1/Mai — Dia do Trabalho
-- 7/Set — Independência
-- 12/Out — Nossa Senhora Aparecida
-- 2/Nov — Finados
-- 15/Nov — Proclamação da República
-- 20/Nov — Consciência Negra
-- 25/Dez — Natal
+Use `current.*` no header do Sprint Review (PASSO 4a) e `next.*` no header do Sprint Planning (PASSO 4c). O header do Review aparece para o usuário validar — se o período estiver errado, ele corrige durante a revisão.
+
+Se hoje não for sexta-feira, confirme com o usuário antes de prosseguir — o próximo sprint usa a mesma duração e propaga o desvio.
 
 ---
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["lib/**/*.ts", "bin/**/*.ts", "__tests__/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

First of three PRs from issue #45: move deterministic date/period logic out of `sprint-start.md` prose into a TypeScript CLI helper.

- **`lib/holidays.ts`** — BR national holidays for any year, including Easter-derived Good Friday (Anonymous Gregorian computus).
- **`lib/period.ts`** — `inferCurrentPeriod(today)`, `nextPeriod(end, workdays)`, `formatPeriodHeader(period)`. Handles Monday edge case, holiday subtraction, multi-year ranges.
- **`bin/sprint.ts`** — CLI dispatcher; `period --today YYYY-MM-DD` returns `{ current, next }` JSON.
- **`tsconfig.json`** — strict, NodeNext, no build step (tsx runtime).
- **`__tests__/period.test.ts`** — 14 unit tests: Good Friday 2025/2026, May 1 holiday, Monday edge case, next-period holiday extension, header formatting.
- **`sprint-start.md` PASSO 1** — replaced ~15 lines of date-math instructions with a single `node -r tsx/cjs` call.
- **`bin/check-skills.sh`** — new guard (check 3) that fails if prose re-introduces date-math keywords.

## Test plan

- [x] `npm test` — 70 tests pass (56 existing + 14 new).
- [x] `node -r tsx/cjs bin/sprint.ts period --today 2026-05-04` returns expected JSON with `2026-05-01` holiday.
- [x] `bin/check-skills.sh` passes against live skill files.
- [ ] Run `/sprint-start` end-to-end and confirm PASSO 1 produces period header from CLI output, not from LLM inference.

## What's next

- PR 2: archive selection + WIP scaffolding (PASSO 1b, PASSO 5).
- PR 3: MCP-result filters (gcal accepted-only, Gmail exclude-Amazon, GitHub date window).

Part of #45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)