### PR TITLE
fix: skill prose hardening — English output, classification rules, mandatory filters, transcripts, auto-upload

### DIFF
--- a/sprint-close.md
+++ b/sprint-close.md
@@ -17,12 +17,15 @@ Informe ao usuário: "Encontrei o rascunho do sprint [period]. Vou coletar os da
 
 ## PASSO 2: Completar dados automaticamente
 
-Execute em paralelo **sem pedir permissão**:
+Execute em paralelo **sem pedir permissão** (período = `generated_at` do rascunho até agora, para capturar trabalho do fim de semana e dias de gap):
 - `list_completed_tasks_by_date` (TickTick) — da data de geração do rascunho até agora
 - `gcal_list_events` — mesmo período
 - `gmail_search_messages` — mesmo período
+- **Claude Code transcripts** — `find ~/.claude/projects/ -maxdepth 2 -name "*.jsonl" -newermt generated_at ! -newermt now`. Por sessão, extraia: objetivo, resultado, PRs/issues referenciados. **Delegue a um subagente Explore.**
 
-Para os dois últimos, passe a resposta JSON via heredoc para o filtro (evita problemas de quoting):
+**Filtro obrigatório.** Após cada chamada MCP (`gcal_list_events`, `gmail_search_messages`), passe o resultado pelo subcomando correspondente ANTES de qualquer outro uso. Bypass do filtro reintroduz os bugs que ele foi criado para evitar.
+
+Para os filtros, passe o JSON via heredoc:
 
 ```bash
 node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal <<'JSON'
@@ -65,9 +68,13 @@ Mescle o rascunho com os novos dados:
 - Complete as seções narrativas (What could be improved, What will I commit) se ainda pendentes
 - Ajuste o Sprint Planning se necessário
 
+**Output language is English.** All Outcomes, Outputs, narratives, and table entries must be in English. Translate any Portuguese source data.
+
 **Ao adicionar Outputs/Outcomes**, siga as mesmas regras do `/sprint-start`:
 - **Outcome** = o estado do mundo mudou (aprovação recebida, decisão final, conta encerrada). Submeter / enviar / abrir / publicar é **Output**, não Outcome.
 - **Outputs** começam com substantivo, não com verbo. ✗ "Sent resume to Google" → ✓ "Google resume". ✗ "Published 4 editions" → ✓ "4 editions".
+- **Exclusions** (never list): stats/analytics summaries from third parties; incoming emails/replies; calendar events the user did not accept.
+- **Timestamp scope** (differs from `/sprint-start`): include work from `generated_at` through today — gap-day work is exactly what `/sprint-close` exists to capture. Do not cap at `current.end`.
 
 Entregue o documento final limpo (sem `[PENDING]`, sem comentários), **no mesmo formato markdown do rascunho** (headers `#`/`##`/`###`, bullets `*`, tabelas com `:----`, listas numeradas para prioridades e outputs) — pronto para copy/paste direto no Google Docs.
 
@@ -97,3 +104,15 @@ node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts archive-wip --repo <<REPO_PATH>> --d
 O comando cria `.sprints/archive/<DATA>.md` (sobrescreve em reruns do mesmo ciclo — intencional).
 
 O arquivo arquivado é a **fonte de contexto** que `/sprint-start` (PASSO 1b) lê na próxima sexta para preservar "On my mind", "On hold" e metas de Health entre sprints. Não apague — sobrescrever o `sprint-wip.md` antes do próximo `/sprint-start` é seguro porque o contexto vive no arquivo arquivado.
+
+3. **Upload automático para o Google Doc:**
+
+```bash
+node <<REPO_PATH>>/upload-sprint.js
+```
+
+Em caso de erro:
+- `invalid_grant` → token expirado. Instrua o usuário: `rm token.json && node upload-sprint.js` para reautenticar no browser.
+- `APPS_SCRIPT_ID not set` → configuração inicial incompleta. Redirecionar para SETUP.md.
+
+O upload é recuperável — os arquivos locais já estão salvos e arquivados. Não falhe o sprint-close inteiro por causa de um erro de upload.

--- a/sprint-close.md
+++ b/sprint-close.md
@@ -21,7 +21,7 @@ Execute em paralelo **sem pedir permissão** (período = `generated_at` do rascu
 - `list_completed_tasks_by_date` (TickTick) — da data de geração do rascunho até agora
 - `gcal_list_events` — mesmo período
 - `gmail_search_messages` — mesmo período
-- **Claude Code transcripts** — `find ~/.claude/projects/ -maxdepth 2 -name "*.jsonl" -newermt generated_at ! -newermt now`. Por sessão, extraia: objetivo, resultado, PRs/issues referenciados. **Delegue a um subagente Explore.**
+- **Claude Code transcripts** — `find ~/.claude/projects/ -maxdepth 2 -name "*.jsonl" -newermt 'generated_at'` (substitua a data literalmente em formato `YYYY-MM-DD`). Por sessão, extraia: objetivo, resultado, PRs/issues referenciados. **Delegue a um subagente Explore.**
 
 **Filtro obrigatório.** Após cada chamada MCP (`gcal_list_events`, `gmail_search_messages`), passe o resultado pelo subcomando correspondente ANTES de qualquer outro uso. Bypass do filtro reintroduz os bugs que ele foi criado para evitar.
 
@@ -68,9 +68,8 @@ Mescle o rascunho com os novos dados:
 - Complete as seções narrativas (What could be improved, What will I commit) se ainda pendentes
 - Ajuste o Sprint Planning se necessário
 
-**Output language is English.** All Outcomes, Outputs, narratives, and table entries must be in English. Translate any Portuguese source data.
-
 **Ao adicionar Outputs/Outcomes**, siga as mesmas regras do `/sprint-start`:
+- **Output language is English.** Outcomes, Outputs, narrativas e tabelas em inglês — traduzir qualquer dado-fonte em português.
 - **Outcome** = o estado do mundo mudou (aprovação recebida, decisão final, conta encerrada). Submeter / enviar / abrir / publicar é **Output**, não Outcome.
 - **Outputs** começam com substantivo, não com verbo. ✗ "Sent resume to Google" → ✓ "Google resume". ✗ "Published 4 editions" → ✓ "4 editions".
 - **Exclusions** (never list): stats/analytics summaries from third parties; incoming emails/replies; calendar events the user did not accept.

--- a/sprint-start.md
+++ b/sprint-start.md
@@ -51,14 +51,17 @@ Execute em paralelo **sem pedir permissão**:
 - `list_projects` (TickTick)
 - `gcal_list_calendars` (Google Calendar)
 
-**Lote B** (com IDs em mãos):
-- `list_completed_tasks_by_date` (TickTick) — início do sprint até agora
+**Lote B** (com IDs em mãos, período = `current.start` a `current.end` do PASSO 1):
+- `list_completed_tasks_by_date` (TickTick) — `current.start` até `current.end`
 - `list_undone_tasks_by_date` (TickTick) — tarefas abertas
-- `gcal_list_events` — eventos do sprint até hoje; depois filtre conforme abaixo
-- `gmail_search_messages` — emails do período; depois filtre conforme abaixo
+- `gcal_list_events` — `current.start` até `current.end`; depois filtre conforme abaixo
+- `gmail_search_messages` — mesmo período; depois filtre conforme abaixo
 - `gh api "/users/vjpixel/events?per_page=50"` (GitHub); depois filtre conforme abaixo
+- **Claude Code transcripts** — `find ~/.claude/projects/ -maxdepth 2 -name "*.jsonl" -newermt current.start ! -newermt current.end+1day`. Para cada arquivo top-level, extraia: primeira mensagem do usuário (objetivo da sessão), última mensagem do assistente (o que foi feito), PRs/issues referenciados. **Delegue a um subagente Explore** para não poluir o contexto principal.
 
-Para cada um dos três acima, passe a resposta JSON via heredoc (evita problemas de quoting com aspas, backticks, `$`, etc.):
+**Filtro obrigatório.** Após CADA chamada MCP (`gcal_list_events`, `gmail_search_messages`, `gh api events`), passe o resultado pelo subcomando correspondente ANTES de qualquer outro uso — inclusive contagem, sumarização ou exibição parcial. Bypass do filtro (ex.: parsear o JSON diretamente em Node one-liner) reintroduz os bugs que o filtro foi criado para evitar.
+
+Passe o JSON via heredoc (evita quoting issues com aspas, backticks, `$`):
 
 ```bash
 node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal <<'JSON'
@@ -66,7 +69,7 @@ node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal <<'JSON'
 JSON
 ```
 
-Use `filter-gmail` (sem flags) e `filter-github --start YYYY-MM-DD --end YYYY-MM-DD` para os outros dois. Cada comando lê do stdin e retorna o array filtrado em stdout.
+Use `filter-gmail` (sem flags) e `filter-github --start current.start --end current.end` para os outros dois. Cada comando lê do stdin e retorna o array filtrado em stdout.
 
 ---
 
@@ -128,6 +131,16 @@ Gere e exiba **apenas o Sprint Review**. Marque campos incompletos com `[PENDING
 ```
 
 **Regras de classificação:**
+
+**Output language is English.** All Outcomes, Outputs, narratives, and table entries must be written in English regardless of source-data language (TickTick titles in PT-BR, Gmail subjects, etc.). Translate Portuguese task titles into English noun phrases.
+
+**Timestamp guard.** Every Outcome and Output must have a timestamp inside `[current.start, current.end]` (inclusive, local timezone). Work done after `current.end` belongs to the next sprint — do not include catch-up work from gap days.
+
+**Exclusions** (never list as Outputs or Outcomes):
+- Stats/analytics summaries from third parties (Beehiiv recaps, GitHub star counts) — these are observations, not outputs. May inform the Retro; never the Review.
+- Incoming communications (received emails, replies, DMs) — the user didn't produce these.
+- Calendar events the user did NOT accept (`myResponseStatus !== 'accepted'`) — often other people's schedules shared with the user, not the user's commitments.
+
 - **Outcomes** = o que mudou no mundo: decisões tomadas, acordos fechados, status alterado, marcos atingidos. Pergunte: *"isso mudou o estado do mundo, ou só produziu um artefato/comunicação?"*. Se só produziu, é Output.
   - Outcomes: aprovação recebida, contratado/aprovado num assessment, conta encerrada, proposta aceita, decisão final tomada.
   - **Não-Outcomes:** submeter proposta, enviar currículo, abrir PR, publicar edição — esses são Outputs (o artefato existe; o mundo ainda não mudou).
@@ -169,7 +182,7 @@ Aguarde confirmação antes de continuar.
 
 ## PASSO 4b: Sprint Retrospective
 
-Após confirmação do Review, gere e exiba **apenas o Sprint Retrospective**.
+Após confirmação do Review, gere e exiba **apenas o Sprint Retrospective**. All generated content must be in English (see PASSO 4a for the full rule).
 
 ```
 ## Sprint Retrospective *([período], X workdays)*
@@ -215,7 +228,7 @@ Aguarde confirmação antes de continuar.
 
 ## PASSO 4c: Sprint Planning
 
-Após confirmação da Retro, gere e exiba **apenas o Sprint Planning**.
+Após confirmação da Retro, gere e exiba **apenas o Sprint Planning**. All generated content must be in English (see PASSO 4a for the full rule).
 
 ```
 ## Sprint Planning *([próximo período], X workdays)*

--- a/sprint-start.md
+++ b/sprint-start.md
@@ -57,7 +57,7 @@ Execute em paralelo **sem pedir permissão**:
 - `gcal_list_events` — `current.start` até `current.end`; depois filtre conforme abaixo
 - `gmail_search_messages` — mesmo período; depois filtre conforme abaixo
 - `gh api "/users/vjpixel/events?per_page=50"` (GitHub); depois filtre conforme abaixo
-- **Claude Code transcripts** — `find ~/.claude/projects/ -maxdepth 2 -name "*.jsonl" -newermt current.start ! -newermt current.end+1day`. Para cada arquivo top-level, extraia: primeira mensagem do usuário (objetivo da sessão), última mensagem do assistente (o que foi feito), PRs/issues referenciados. **Delegue a um subagente Explore** para não poluir o contexto principal.
+- **Claude Code transcripts** — calcule `dayAfterEnd` = dia seguinte a `current.end` em formato `YYYY-MM-DD` (ex.: `current.end=2026-05-03` → `dayAfterEnd=2026-05-04`), então rode (substituindo as duas datas literalmente): `find ~/.claude/projects/ -maxdepth 2 -name "*.jsonl" -newermt 'current.start' ! -newermt 'dayAfterEnd'`. Para cada arquivo top-level, extraia: primeira mensagem do usuário (objetivo), última mensagem do assistente (resultado), PRs/issues referenciados. **Delegue a um subagente Explore** para não poluir o contexto principal.
 
 **Filtro obrigatório.** Após CADA chamada MCP (`gcal_list_events`, `gmail_search_messages`, `gh api events`), passe o resultado pelo subcomando correspondente ANTES de qualquer outro uso — inclusive contagem, sumarização ou exibição parcial. Bypass do filtro (ex.: parsear o JSON diretamente em Node one-liner) reintroduz os bugs que o filtro foi criado para evitar.
 

--- a/sprint-update.md
+++ b/sprint-update.md
@@ -25,6 +25,8 @@ Apply all changes in one pass.
 
 ## STEP 3: Save
 
+Apply edits in **English** — translate any Portuguese input from the user into English before integrating into the document.
+
 Overwrite `<<REPO_PATH>>/.sprints/sprint-wip.md` with the updated content, preserving the `<!-- sprint-wip: ... -->` header.
 
 Confirm: "Done. Draft updated."


### PR DESCRIPTION
## Summary

Applies six systematic fixes to `sprint-start.md`, `sprint-update.md`, and `sprint-close.md` based on errors caught during a real run on 2026-05-05. No code changes — prose only.

| Issue | Change |
|---|---|
| **#49** English output | Rule added to PASSO 4a/4b/4c and sprint-update STEP 3: all generated content must be in English. |
| **#51** In-sprint work only | PASSO 2 date bounds changed from "until today" to `[current.start, current.end]`; sprint-close clarifies its scope covers gap days. |
| **#52** Output classification | Three exclusion bullets in PASSO 4a: stats dumps, incoming emails, non-accepted calendar events are never Outputs. |
| **#53** Mandatory filter pipeline | Prominent rule before filter blocks: bypassing `filter-*` CLIs reintroduces the bugs they prevent. |
| **#54** Claude Code transcripts | New source in PASSO 2 (both files): top-level `.jsonl` sessions filtered by mtime, extracted via Explore subagent. |
| **#55** Auto-upload to Docs | Step 3 in sprint-close PASSO 6: `node upload-sprint.js` runs automatically after archive; surfaces clear error messages for token/config issues. |

## Test plan

- [x] `npm test` — 127 tests pass (`check-skills.sh` guards still pass against live files).
- [x] `npm run install-skills` — installs cleanly, no `<<REPO_PATH>>` tokens.
- [ ] Manual end-to-end: run `/sprint-start` and confirm Review/Retro/Planning are in English, data collection is bounded to sprint window, and transcripts are fetched via subagent.
- [ ] Run `/sprint-close` and confirm auto-upload runs (or surfaces clear error).

Closes #49, #51, #52, #53, #54, #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)