### PR TITLE
fix(#58): parse improvement_goals[] from archive + use in Retro/Planning

### DIFF
--- a/__tests__/archive.test.ts
+++ b/__tests__/archive.test.ts
@@ -129,6 +129,29 @@ test('parsePriorPlanning: no improvement table returns empty array', () => {
   assert.deepEqual(r.improvement_goals, []);
 });
 
+test('parsePriorPlanning: ignores Retro two-column "| Improvement | Result |" table', () => {
+  // Regression: a real archive has BOTH the Retrospective table (2 columns:
+  // Improvement | Result) AND the Planning table (1 column). The parser must
+  // pick the single-column Planning table, not the 2-column Retro one.
+  const content = `
+### Last week's improvement goals
+
+| Improvement | Result |
+| :---- | :---: |
+| Old goal A | **3 / 5** |
+| Old goal B | **1 / 5** |
+
+### Next week's goals
+
+| Improvement |
+| :---- |
+| New goal A |
+| New goal B |
+`;
+  const r = parsePriorPlanning(content);
+  assert.deepEqual(r.improvement_goals, ['New goal A', 'New goal B']);
+});
+
 // loadLatestArchive
 
 test('loadLatestArchive: returns null when no archive exists', () => {

--- a/__tests__/archive.test.ts
+++ b/__tests__/archive.test.ts
@@ -42,6 +42,8 @@ Job Hunt — aguardando resposta da Google
 | Improvement |
 | :---- |
 | Work +2h |
+| Spend 1+ hours OoH |
+| Make impact |
 
 | Health | Goal |
 | :---- | :---- |
@@ -117,6 +119,16 @@ test('parsePriorPlanning: no health table returns empty object', () => {
   assert.deepEqual(r.health_goals, {});
 });
 
+test('parsePriorPlanning: extracts improvement_goals from single-column table', () => {
+  const r = parsePriorPlanning(SAMPLE_PLANNING);
+  assert.deepEqual(r.improvement_goals, ['Work +2h', 'Spend 1+ hours OoH', 'Make impact']);
+});
+
+test('parsePriorPlanning: no improvement table returns empty array', () => {
+  const r = parsePriorPlanning('## On my mind\nitem\n');
+  assert.deepEqual(r.improvement_goals, []);
+});
+
 // loadLatestArchive
 
 test('loadLatestArchive: returns null when no archive exists', () => {
@@ -132,4 +144,5 @@ test('loadLatestArchive: returns structured data for latest archive', () => {
   assert.equal(result.date, '2026-04-27');
   assert.deepEqual(result.on_my_mind, ['Verificar status do projeto X', 'Responder email do João']);
   assert.equal(result.health_goals['Sleep Score'], '82');
+  assert.deepEqual(result.improvement_goals, ['Work +2h', 'Spend 1+ hours OoH', 'Make impact']);
 });

--- a/lib/archive.ts
+++ b/lib/archive.ts
@@ -7,6 +7,7 @@ export interface ArchiveContext {
   on_my_mind: string[];
   on_hold: string[];
   health_goals: Record<string, string>;
+  improvement_goals: string[];
 }
 
 export function latestArchivePath(repoPath: string): string | null {
@@ -23,22 +24,24 @@ export function latestArchivePath(repoPath: string): string | null {
   return fs.existsSync(legacy) ? legacy : null;
 }
 
-export function parsePriorPlanning(content: string): Pick<ArchiveContext, 'on_my_mind' | 'on_hold' | 'health_goals'> {
+export function parsePriorPlanning(content: string): Pick<ArchiveContext, 'on_my_mind' | 'on_hold' | 'health_goals' | 'improvement_goals'> {
   const lines = content.split('\n');
   const on_my_mind: string[] = [];
   const on_hold: string[] = [];
   const health_goals: Record<string, string> = {};
+  const improvement_goals: string[] = [];
 
   type Section = 'none' | 'on_my_mind' | 'on_hold';
   let section: Section = 'none';
   let inHealthTable = false;
+  let inImprovementTable = false;
 
   for (const raw of lines) {
     const line = raw.trim();
 
-    if (line === '## On my mind') { section = 'on_my_mind'; inHealthTable = false; continue; }
-    if (line === '## On hold') { section = 'on_hold'; inHealthTable = false; continue; }
-    if (line.startsWith('#')) { section = 'none'; inHealthTable = false; }
+    if (line === '## On my mind') { section = 'on_my_mind'; inHealthTable = false; inImprovementTable = false; continue; }
+    if (line === '## On hold') { section = 'on_hold'; inHealthTable = false; inImprovementTable = false; continue; }
+    if (line.startsWith('#')) { section = 'none'; inHealthTable = false; inImprovementTable = false; }
 
     if (section === 'on_my_mind' && line && !line.startsWith('#')) {
       on_my_mind.push(line.replace(/^[*-]\s*/, ''));
@@ -47,7 +50,7 @@ export function parsePriorPlanning(content: string): Pick<ArchiveContext, 'on_my
       on_hold.push(line.replace(/^[*-]\s*/, ''));
     }
 
-    if (/^\|\s*Health\s*\|\s*Goal\s*\|/i.test(line)) { inHealthTable = true; continue; }
+    if (/^\|\s*Health\s*\|\s*Goal\s*\|/i.test(line)) { inHealthTable = true; inImprovementTable = false; continue; }
     if (inHealthTable) {
       const isSeparator = /^\|[\s:|-]+\|$/.test(line) && /-/.test(line);
       if (line.startsWith('|') && !isSeparator) {
@@ -57,9 +60,20 @@ export function parsePriorPlanning(content: string): Pick<ArchiveContext, 'on_my
         inHealthTable = false;
       }
     }
+
+    if (/^\|\s*Improvement\s*\|$/i.test(line)) { inImprovementTable = true; inHealthTable = false; continue; }
+    if (inImprovementTable) {
+      const isSeparator = /^\|[\s:|-]+\|$/.test(line) && /-/.test(line);
+      if (line.startsWith('|') && !isSeparator) {
+        const cells = line.split('|').map(c => c.replace(/\*\*/g, '').trim()).filter(Boolean);
+        if (cells.length >= 1 && cells[0]) improvement_goals.push(cells[0]);
+      } else if (!line.startsWith('|')) {
+        inImprovementTable = false;
+      }
+    }
   }
 
-  return { on_my_mind, on_hold, health_goals };
+  return { on_my_mind, on_hold, health_goals, improvement_goals };
 }
 
 export function loadLatestArchive(repoPath: string): ArchiveContext | null {

--- a/sprint-start.md
+++ b/sprint-start.md
@@ -32,8 +32,9 @@ O retorno é `null` no primeiro uso (sem `.sprints/archive/` ou `sprint-final.md
 - `on_my_mind[]` — itens do sprint anterior
 - `on_hold[]` — itens em espera
 - `health_goals{}` — metas de Health anteriores (ex.: `{"Meditate":"7 days","Sleep Score":"82"}`)
+- `improvement_goals[]` — alvos de Improvement anteriores (ex.: `["Work +2h in important outputs", "Spend 1+ hours OoH", "Make impact"]`)
 
-Aplique `on_my_mind`, `on_hold` e `health_goals` no PASSO 4c. Itens só são removidos se houver sinal **explícito** nos dados do PASSO 2 — nunca por inferência genérica:
+Aplique `improvement_goals` e `health_goals` no PASSO 4b (avaliação do sprint que acabou) e `on_my_mind`, `on_hold`, `health_goals` no PASSO 4c (planejamento do próximo sprint). Itens só são removidos de `on_my_mind` / `on_hold` se houver sinal **explícito** nos dados do PASSO 2 — nunca por inferência genérica:
 
 - Remover de **On my mind** se: tarefa concluída em TickTick OU email de decisão/aprovação em Gmail.
 - Mover de **On hold** para **Projects Priority** se: bloqueador respondeu por email/calendário OU tarefas reativadas em TickTick.
@@ -189,18 +190,17 @@ Após confirmação do Review, gere e exiba **apenas o Sprint Retrospective**. A
 
 | Improvement | Result |
 | :---- | :---: |
-| Work +2h in important outputs | **[PENDING] / X** |
-| Spend 1+ hours OoH | **[PENDING] / X** |
-| Make impact | **[PENDING] / X** |
+| [improvement_goals[0] do archive] | **[PENDING] / X** |
+| [improvement_goals[1] do archive] | **[PENDING] / X** |
+| [improvement_goals[2] do archive] | **[PENDING] / X** |
 
 ### Health goals
 
 | Health | Result |
 | :---- | :---: |
-| Meditate | **[PENDING] / 7** |
-| Exercise | **[PENDING] / X** |
-| Bedtime | **[PENDING] / [meta anterior]** |
-| Wake-up time | **[PENDING] / [meta anterior]** |
+| [chave 1 de health_goals] | **[PENDING] / [meta do archive]** |
+| [chave 2 de health_goals] | **[PENDING] / [meta do archive]** |
+| [chave 3 de health_goals] | **[PENDING] / [meta do archive]** |
 
 ### What did I do well?
 
@@ -215,6 +215,11 @@ Após confirmação do Review, gere e exiba **apenas o Sprint Retrospective**. A
 * [1 bullet — compromisso concreto para o próximo sprint]
 ```
 
+- **Tabelas vêm do archive** (PASSO 1b):
+  - "Last week's improvement goals" → use as 3 linhas de `improvement_goals[]` exatamente como vieram. Não invente nem reuse labels fixos.
+  - "Health goals" → use as chaves de `health_goals{}` exatamente como vieram, com a meta no denominador (ex.: `{"Meditate":"7 days"}` → linha `| Meditate | **[PENDING] / 7 days** |`).
+  - Se o archive for `null` (primeiro uso) OU as listas vierem vazias, mantenha as 3 linhas placeholder com `[PENDING] / ?` e adicione nota: "(archive sem metas anteriores — preencher manualmente)".
+- Result column: marque com `[PENDING] / X` quando não conseguir derivar dos dados; o usuário preenche.
 - Rascunhar as 3 seções narrativas agora — não deixar como [PENDING]
 - Cada seção narrativa tem exatamente 1 bullet
 - "What did I do well?" foca em melhorias no sistema de trabalho
@@ -260,18 +265,19 @@ Após confirmação da Retro, gere e exiba **apenas o Sprint Planning**. All gen
 
 | Improvement |
 | :---- |
-| Work +2h in important outputs |
-| Spend 1+ hours OoH |
-| Make impact |
+| [carregar de improvement_goals[] do archive — ou propor 3 novos se vazio] |
+| ... |
+| ... |
 
 | Health | Goal |
 | :---- | :---- |
-| Meditate | **7 days** |
-| Sleep Score | **[propor valor baseado no sprint anterior]** |
+| [chave 1 de health_goals] | **[meta do archive ou novo valor concreto]** |
+| [chave 2 de health_goals] | **[...]** |
 ```
 
 - Usar seção "Projects Priority" (não "Priority order")
-- Health goals: sempre propor números concretos — nunca deixar [PENDING]
+- **Improvements**: por default carregue `improvement_goals[]` do archive (mesmas labels da Retro do PASSO 4b — espelham o ciclo). Só sugira mudanças se o "What will I commit to improving?" da Retro propuser explicitamente uma nova meta — nesse caso, substitua a linha correspondente.
+- **Health goals**: por default carregue as mesmas chaves de `health_goals{}` do archive com as mesmas metas. Só ajuste se o Retrospective sinalizar que vale puxar a meta (ex.: Sleep Score atingido 3 sprints seguidos → propor +2). Sempre propor números concretos — nunca deixar [PENDING].
 - "On my mind" e "On hold": preservar os itens do sprint anterior se não houver indicação de mudança
 - Outcomes: propor um resultado concreto por projeto ativo — o que tornaria o sprint bem-sucedido para aquele projeto
 


### PR DESCRIPTION
## Summary

- `lib/archive.ts` now extracts `improvement_goals[]` from the previous sprint's archived `## Sprint Planning` block (single-column `| Improvement |` table)
- Skill `sprint-start` PASSO 4b (Retrospective) and PASSO 4c (Planning) reference `improvement_goals[]` + `health_goals{}` from the archive instead of hardcoded labels (`Work +2h / OoH / Make impact` and `Meditate / Exercise / Bedtime / Wake-up time`)
- Same pattern as `health_goals{}` from #47 — labels travel with the sprint cycle

## Test plan

- [x] `npm test` — 71/71 pass, including 2 new tests in `__tests__/archive.test.ts`
- [x] `node -r tsx/cjs bin/sprint.ts archive` against `.sprints/archive/2026-05-10.md` returns `improvement_goals: ["Work +2h in important outputs", "Spend 1+ hours OoH", "Make impact"]`
- [ ] Next `/sprint-start` (segunda 18/05) usa as labels do archive na tabela "Last week's improvement goals" — validar no ciclo completo

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)