### PR TITLE
fix(#60): scrum-style retro answers — concise, action-oriented

### DIFF
--- a/sprint-close.md
+++ b/sprint-close.md
@@ -65,7 +65,7 @@ Coletei os dados que faltaram. Agora preciso dos resultados anotados no papel pa
 Mescle o rascunho com os novos dados:
 - Substitua todos os `[PENDING]` pelos valores reais
 - Adicione os novos Outputs/Outcomes do fim de semana
-- Complete as seções narrativas (What could be improved, What will I commit) se ainda pendentes
+- Complete as seções narrativas (What could be improved, What will I commit) se ainda pendentes — em **estilo scrum** (bullets curtos e acionáveis; o "commit" é um action item concreto e rastreável, conforme `/sprint-start` PASSO 4b)
 - Ajuste o Sprint Planning se necessário
 
 **Ao adicionar Outputs/Outcomes**, siga as mesmas regras do `/sprint-start`:

--- a/sprint-start.md
+++ b/sprint-start.md
@@ -204,15 +204,15 @@ Após confirmação do Review, gere e exiba **apenas o Sprint Retrospective**. A
 
 ### What did I do well?
 
-* [1 bullet — foco em melhorias no sistema de trabalho: ferramentas, hábitos, processos]
+* [1 bullet curto — melhoria no sistema de trabalho (ferramenta, hábito, processo)]
 
 ### What could be improved?
 
-* [1 bullet — algo estrutural, não uma tarefa esquecida]
+* [1 bullet curto — algo estrutural, não uma tarefa esquecida]
 
 ### What will I commit to improving?
 
-* [1 bullet — compromisso concreto para o próximo sprint]
+* [1 bullet — action item concreto e rastreável (próximo passo claro), não uma descrição]
 ```
 
 - **Tabelas vêm do archive** (PASSO 1b):
@@ -223,6 +223,10 @@ Após confirmação do Review, gere e exiba **apenas o Sprint Retrospective**. A
 - Rascunhar as 3 seções narrativas agora — não deixar como [PENDING]
 - Cada seção narrativa tem exatamente 1 bullet
 - "What did I do well?" foca em melhorias no sistema de trabalho
+- **Estilo scrum — conciso e acionável:**
+  - Cada bullet = **1 ideia clara, curta e escaneável** (~≤ 1 linha). Evite frases compostas com várias cláusulas/travessões; corte o "porquê" longo e deixe a ação falar.
+  - Frasear de forma **acionável**. Em especial, "What will I commit to improving?" deve ser um **action item concreto e rastreável** — próximo passo claro, idealmente mensurável ou time-boxed — não uma frase descritiva.
+  - Opcional: enquadrar as três seções como **Start / Stop / Continue** quando ajudar a tornar a ação explícita.
 
 Após exibir, pergunte: **"Retro OK? Algo para ajustar?"**
 Aguarde confirmação antes de continuar.


### PR DESCRIPTION
Closes #60.

## What
Adds scrum-style guidance to the Sprint Retrospective so future runs produce concise, action-oriented answers instead of long prose.

- **`sprint-start.md` PASSO 4b** — new guidance: each narrative bullet is one clear, scannable idea (~≤1 line, no compound clauses); phrase action-oriented; **"What will I commit to improving?" must be a concrete, trackable action item** (clear next step, ideally measurable/time-boxed). Optional Start/Stop/Continue framing. Template placeholders tightened to match.
- **`sprint-close.md`** — mirrors the note where it completes pending narrative sections.
- **`sprint-update.md`** — no retro-generation section, so no change needed.

## Why
The generated retro bullets read like prose, not a scrum retro (hard to scan, "commit" wasn't a trackable action). Surfaced during the Jun 1–7 sprint review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)