### PR TITLE
feat(#61): frontmatter-as-data for sprint archives + Obsidian vault

### DIFF
--- a/__tests__/archive.test.ts
+++ b/__tests__/archive.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { latestArchivePath, parsePriorPlanning, loadLatestArchive } from '../lib/archive.js';
+import { latestArchivePath, parsePriorPlanning, parseFrontmatter, loadLatestArchive } from '../lib/archive.js';
 
 function makeTmpRepo(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 're-plan-test-'));
@@ -168,4 +168,75 @@ test('loadLatestArchive: returns structured data for latest archive', () => {
   assert.deepEqual(result.on_my_mind, ['Verificar status do projeto X', 'Responder email do João']);
   assert.equal(result.health_goals['Sleep Score'], '82');
   assert.deepEqual(result.improvement_goals, ['Work +2h', 'Spend 1+ hours OoH', 'Make impact']);
+});
+
+// parseFrontmatter (frontmatter-as-data, #61)
+
+const SAMPLE_FRONTMATTER = `---
+type: sprint
+review_period: 1/Jun–7/Jun
+review_workdays: 5
+plan_period: 8/Jun–14/Jun
+projects:
+  - Diar.ia
+  - Jandig
+improvement_goals:
+  - Stop working by 9 PM
+  - Make impact
+health_goals:
+  Meditate: 4 days
+  Sleep Score: avg ≥ 80
+on_my_mind:
+  - Job Hunt (awaiting Google's response)
+  - FAPESP proposal
+on_hold: []
+---
+<!-- sprint-wip: 8/Jun–14/Jun -->
+
+## On my mind
+
+Prose value that must be ignored when frontmatter exists
+`;
+
+test('parseFrontmatter: returns null without frontmatter', () => {
+  assert.equal(parseFrontmatter('# just prose\nno frontmatter here\n'), null);
+});
+
+test('parseFrontmatter: returns null when frontmatter has no planning keys', () => {
+  assert.equal(parseFrontmatter('---\ntype: sprint\nreview_workdays: 5\n---\n'), null);
+});
+
+test('parseFrontmatter: parses block lists, nested map, and empty list', () => {
+  const r = parseFrontmatter(SAMPLE_FRONTMATTER);
+  assert.ok(r);
+  assert.deepEqual(r.on_my_mind, ["Job Hunt (awaiting Google's response)", 'FAPESP proposal']);
+  assert.deepEqual(r.on_hold, []);
+  assert.deepEqual(r.improvement_goals, ['Stop working by 9 PM', 'Make impact']);
+  assert.equal(r.health_goals['Meditate'], '4 days');
+  assert.equal(r.health_goals['Sleep Score'], 'avg ≥ 80');
+});
+
+test('parseFrontmatter: supports inline list and inline empty list', () => {
+  const r = parseFrontmatter('---\non_my_mind: [a, b]\non_hold: []\n---\n');
+  assert.ok(r);
+  assert.deepEqual(r.on_my_mind, ['a', 'b']);
+  assert.deepEqual(r.on_hold, []);
+});
+
+test('loadLatestArchive: prefers frontmatter over prose body', () => {
+  const repo = makeTmpRepo();
+  writeArchive(repo, '2026-06-07', SAMPLE_FRONTMATTER);
+  const r = loadLatestArchive(repo);
+  assert.ok(r);
+  assert.equal(r.date, '2026-06-07');
+  assert.deepEqual(r.on_my_mind, ["Job Hunt (awaiting Google's response)", 'FAPESP proposal']);
+  assert.equal(r.health_goals['Sleep Score'], 'avg ≥ 80');
+});
+
+test('loadLatestArchive: falls back to prose when no frontmatter', () => {
+  const repo = makeTmpRepo();
+  writeArchive(repo, '2026-06-07', SAMPLE_PLANNING);
+  const r = loadLatestArchive(repo);
+  assert.ok(r);
+  assert.deepEqual(r.improvement_goals, ['Work +2h', 'Spend 1+ hours OoH', 'Make impact']);
 });

--- a/lib/archive.ts
+++ b/lib/archive.ts
@@ -24,7 +24,9 @@ export function latestArchivePath(repoPath: string): string | null {
   return fs.existsSync(legacy) ? legacy : null;
 }
 
-export function parsePriorPlanning(content: string): Pick<ArchiveContext, 'on_my_mind' | 'on_hold' | 'health_goals' | 'improvement_goals'> {
+type PriorPlanning = Pick<ArchiveContext, 'on_my_mind' | 'on_hold' | 'health_goals' | 'improvement_goals'>;
+
+export function parsePriorPlanning(content: string): PriorPlanning {
   const lines = content.split('\n');
   const on_my_mind: string[] = [];
   const on_hold: string[] = [];
@@ -76,6 +78,80 @@ export function parsePriorPlanning(content: string): Pick<ArchiveContext, 'on_my
   return { on_my_mind, on_hold, health_goals, improvement_goals };
 }
 
+function stripScalar(s: string): string {
+  const t = s.trim();
+  if (t.length >= 2 && ((t[0] === '"' && t.endsWith('"')) || (t[0] === "'" && t.endsWith("'")))) {
+    return t.slice(1, -1);
+  }
+  return t;
+}
+
+function parseInlineList(val: string): string[] {
+  const inner = val.slice(1, -1).trim();
+  if (!inner) return [];
+  return inner.split(',').map(stripScalar).filter(s => s.length > 0);
+}
+
+/**
+ * Read the prior sprint's planning fields from leading YAML frontmatter, when
+ * present. Returns null if there is no frontmatter or it carries none of the
+ * planning keys — callers then fall back to parsePriorPlanning (prose) so old,
+ * pre-frontmatter archives keep working. Deliberately a tiny, schema-specific
+ * reader (block lists + one nested map + scalars); no YAML dependency.
+ */
+export function parseFrontmatter(content: string): PriorPlanning | null {
+  const m = content.match(/^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/);
+  if (!m) return null;
+
+  const result: PriorPlanning = { on_my_mind: [], on_hold: [], health_goals: {}, improvement_goals: [] };
+  const listFor: Record<string, string[]> = {
+    on_my_mind: result.on_my_mind,
+    on_hold: result.on_hold,
+    improvement_goals: result.improvement_goals,
+  };
+  let sawPlanningKey = false;
+
+  type Collector = { kind: 'list'; arr: string[] } | { kind: 'map'; obj: Record<string, string> } | null;
+  let collector: Collector = null;
+
+  for (const rawLine of m[1].split(/\r?\n/)) {
+    if (!rawLine.trim() || /^\s*#/.test(rawLine)) continue;
+    const indent = rawLine.length - rawLine.replace(/^\s+/, '').length;
+    const line = rawLine.trim();
+
+    if (collector && indent > 0) {
+      if (collector.kind === 'list' && line.startsWith('- ')) {
+        collector.arr.push(stripScalar(line.slice(2)));
+        continue;
+      }
+      if (collector.kind === 'map') {
+        const kv = line.match(/^(.+?):\s*(.*)$/);
+        if (kv) collector.obj[stripScalar(kv[1])] = stripScalar(kv[2]);
+        continue;
+      }
+    }
+
+    const top = indent === 0 ? rawLine.match(/^([A-Za-z_][\w-]*):[ \t]*(.*)$/) : null;
+    collector = null;
+    if (!top) continue;
+
+    const key = top[1];
+    const val = top[2].trim();
+
+    if (Object.prototype.hasOwnProperty.call(listFor, key)) {
+      sawPlanningKey = true;
+      const arr = listFor[key];
+      if (val.startsWith('[') && val.endsWith(']')) parseInlineList(val).forEach(x => arr.push(x));
+      else if (val === '') collector = { kind: 'list', arr };
+    } else if (key === 'health_goals') {
+      sawPlanningKey = true;
+      if (val === '') collector = { kind: 'map', obj: result.health_goals };
+    }
+  }
+
+  return sawPlanningKey ? result : null;
+}
+
 export function loadLatestArchive(repoPath: string): ArchiveContext | null {
   const filePath = latestArchivePath(repoPath);
   if (!filePath) return null;
@@ -84,5 +160,8 @@ export function loadLatestArchive(repoPath: string): ArchiveContext | null {
   const dateMatch = path.basename(filePath).match(/^(\d{4}-\d{2}-\d{2})\.md$/);
   const date = dateMatch ? dateMatch[1] : 'unknown';
 
-  return { path: filePath, date, ...parsePriorPlanning(content) };
+  // Frontmatter is authoritative when present; prose parsing is the fallback
+  // for archives written before the frontmatter schema (#61).
+  const planning = parseFrontmatter(content) ?? parsePriorPlanning(content);
+  return { path: filePath, date, ...planning };
 }

--- a/sprint-close.md
+++ b/sprint-close.md
@@ -67,6 +67,7 @@ Mescle o rascunho com os novos dados:
 - Adicione os novos Outputs/Outcomes do fim de semana
 - Complete as seções narrativas (What could be improved, What will I commit) se ainda pendentes — em **estilo scrum** (bullets curtos e acionáveis; o "commit" é um action item concreto e rastreável, conforme `/sprint-start` PASSO 4b)
 - Ajuste o Sprint Planning se necessário
+- Mantenha o **frontmatter YAML** do topo em sincronia com os valores finais do Planning (`improvement_goals`, `health_goals`, `on_my_mind`, `on_hold`) — é o que o próximo `/sprint-start` lê via `bin/sprint.ts archive`
 
 **Ao adicionar Outputs/Outcomes**, siga as mesmas regras do `/sprint-start`:
 - **Output language is English.** Outcomes, Outputs, narrativas e tabelas em inglês — traduzir qualquer dado-fonte em português.

--- a/sprint-start.md
+++ b/sprint-start.md
@@ -303,10 +303,37 @@ Aguarde confirmação antes de continuar.
 
 Após confirmação do Planning, salve o documento completo (plano do dia + Review + Retro + Planning) no arquivo `<<REPO_PATH>>/.sprints/sprint-wip.md`.
 
-Inclua obrigatoriamente na primeira linha:
+O arquivo **começa com um bloco de frontmatter YAML** (linha 1 = `---`) que espelha os campos do Planning — é o que o `bin/sprint.ts archive` lê no próximo ciclo (`lib/archive.ts`) e o que alimenta o dashboard Obsidian (`.sprints/Dashboard.md`). Logo abaixo dele, o comentário `sprint-wip` legível:
+
 ```
+---
+type: sprint
+review_period: [período do Review, ex: 1/Jun–7/Jun]
+review_workdays: [N]
+plan_period: [período do Planning, ex: 8/Jun–14/Jun]
+plan_workdays: [N]
+generated: [YYYY-MM-DD]
+projects:
+  - [Projeto 1]
+  - [Projeto 2]
+improvement_goals:
+  - [meta 1]
+  - [meta 2]
+  - [meta 3]
+health_goals:
+  [Chave 1]: [meta]
+  [Chave 2]: [meta]
+on_my_mind:
+  - [item]
+on_hold: []
+---
 <!-- sprint-wip: [período em formato legível, ex: 27/Abr–3/Mai] | gerado em: [data e hora locais] -->
 ```
+
+Regras do frontmatter:
+- `improvement_goals`, `health_goals`, `on_my_mind`, `on_hold` = exatamente os valores da seção **Planning** (PASSO 4c) — viram o "archive" lido pelo próximo sprint.
+- Liste vazios como `[]` (nunca omita a chave). Listas em bloco (`- item`); `health_goals` é um mapa aninhado (`Chave: meta`).
+- O bloco `---…---` precede tudo (requisito do Obsidian); o comentário `sprint-wip` e o corpo do doc vêm depois.
 
 ---
 


### PR DESCRIPTION
Closes #61. Implements the "frontmatter-as-data first" slice.

## What
- **`lib/archive.ts`** — `parseFrontmatter()` reads the prior sprint's planning fields (`on_my_mind`, `on_hold`, `health_goals`, `improvement_goals`) from leading YAML frontmatter. `loadLatestArchive()` prefers frontmatter and **falls back to the existing prose parser** for pre-frontmatter archives. Tiny schema-specific reader — no new dependency.
- **`__tests__/archive.test.ts`** — frontmatter parsing (block lists, nested map, inline/empty list), precedence over prose, and prose fallback. All 78 tests green.
- **`sprint-start.md` PASSO 5** — the saved doc now starts with a frontmatter block (schema + rules) above the `sprint-wip` comment.
- **`sprint-close.md`** — keep the frontmatter in sync when finalizing.

## Obsidian layer
The vault scaffolding (README, Dataview `Dashboard.md`, `projects/*.md`) is set up under the **gitignored `.sprints/` vault** alongside the sprint data, so it's live for the user without committing personal data. The dashboard renders sprint/goal/health trends, per-project activity, and open carryover from the `type: sprint` frontmatter.

## Why
`lib/archive.ts` previously re-derived structured fields by regex-parsing prose tables/headings. Frontmatter makes the read robust and makes the whole archive queryable in Obsidian — without changing how docs are written or displacing TickTick as the task source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)