### PR TITLE
feat(#64,#65): cross-sprint trends + results-in-frontmatter

### DIFF
--- a/__tests__/archive.test.ts
+++ b/__tests__/archive.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { latestArchivePath, parsePriorPlanning, parseFrontmatter, loadLatestArchive } from '../lib/archive.js';
+import { latestArchivePath, parsePriorPlanning, parseFrontmatter, parseFrontmatterObject, loadLatestArchive } from '../lib/archive.js';
 
 function makeTmpRepo(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 're-plan-test-'));
@@ -239,4 +239,34 @@ test('loadLatestArchive: falls back to prose when no frontmatter', () => {
   const r = loadLatestArchive(repo);
   assert.ok(r);
   assert.deepEqual(r.improvement_goals, ['Work +2h', 'Spend 1+ hours OoH', 'Make impact']);
+});
+
+// parseFrontmatterObject (generic reader, #64/#65)
+
+test('parseFrontmatterObject: scalars, block lists, inline lists, nested map', () => {
+  const o = parseFrontmatterObject(`---
+type: sprint
+review_workdays: 5
+projects:
+  - Diar.ia
+  - Jandig
+tags: [a, b]
+empty: []
+health_goals:
+  Meditate: "4 days"
+  Sleep Score: avg ≥ 80
+---
+body
+`);
+  assert.ok(o);
+  assert.equal(o.type, 'sprint');
+  assert.equal(o.review_workdays, '5');
+  assert.deepEqual(o.projects, ['Diar.ia', 'Jandig']);
+  assert.deepEqual(o.tags, ['a', 'b']);
+  assert.deepEqual(o.empty, []);
+  assert.deepEqual(o.health_goals, { Meditate: '4 days', 'Sleep Score': 'avg ≥ 80' });
+});
+
+test('parseFrontmatterObject: returns null without frontmatter', () => {
+  assert.equal(parseFrontmatterObject('# no frontmatter\n'), null);
 });

--- a/__tests__/trends.test.ts
+++ b/__tests__/trends.test.ts
@@ -1,0 +1,127 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { loadSprintRecords, computeTrends } from '../lib/trends.js';
+
+function makeRepo(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 're-plan-trends-'));
+  fs.mkdirSync(path.join(dir, '.sprints', 'archive'), { recursive: true });
+  return dir;
+}
+function writeArchive(repo: string, date: string, content: string): void {
+  fs.writeFileSync(path.join(repo, '.sprints', 'archive', `${date}.md`), content);
+}
+
+const A = `---
+type: sprint
+review_period: A
+projects:
+  - Diar.ia
+  - Jandig
+improvement_goals:
+  - G1
+health_goals:
+  Meditate: "7 days"
+on_my_mind:
+  - X
+  - Y
+on_hold:
+  - B
+---
+body
+`;
+
+const B = `---
+type: sprint
+projects:
+  - Diar.ia
+improvement_goals:
+  - G1
+  - G2
+health_goals:
+  Meditate: "7 days"
+results_health:
+  Meditate: "5/7"
+results_planned: 3
+results_shipped: 2
+on_my_mind:
+  - X
+on_hold: []
+---
+body
+`;
+
+const C = `---
+type: sprint
+projects:
+  - Diar.ia
+  - Jandig
+improvement_goals:
+  - G2
+health_goals:
+  Meditate: "7 days"
+  Sleep: "80"
+results_improvement:
+  G1: "yes"
+on_my_mind:
+  - X
+  - Z
+on_hold:
+  - B
+---
+body
+`;
+
+function seed(): string {
+  const r = makeRepo();
+  writeArchive(r, '2026-01-05', A);
+  writeArchive(r, '2026-01-12', B);
+  writeArchive(r, '2026-01-19', C);
+  return r;
+}
+
+test('loadSprintRecords: parses all archives ascending with fields', () => {
+  const recs = loadSprintRecords(seed());
+  assert.equal(recs.length, 3);
+  assert.deepEqual(recs.map(r => r.date), ['2026-01-05', '2026-01-12', '2026-01-19']);
+  assert.deepEqual(recs[0].projects, ['Diar.ia', 'Jandig']);
+  assert.deepEqual(recs[2].improvement_goals, ['G2']);
+  assert.equal(recs[2].health_goals['Sleep'], '80');
+});
+
+test('loadSprintRecords: reads results_* (#65)', () => {
+  const recs = loadSprintRecords(seed());
+  assert.equal(recs[1].results_planned, 3);
+  assert.equal(recs[1].results_shipped, 2);
+  assert.equal(recs[1].results_health?.Meditate, '5/7');
+  assert.equal(recs[2].results_improvement?.G1, 'yes');
+  assert.equal(recs[0].results_planned, undefined);
+});
+
+test('computeTrends: carryover age counts consecutive sprints from latest', () => {
+  const t = computeTrends(seed());
+  const omm = Object.fromEntries(t.latest_carryover.on_my_mind.map(c => [c.item, c.age]));
+  assert.equal(omm['X'], 3); // present in C, B, A
+  assert.equal(omm['Z'], 1); // only in C
+  const hold = Object.fromEntries(t.latest_carryover.on_hold.map(c => [c.item, c.age]));
+  assert.equal(hold['B'], 1); // C yes, B absent -> stops
+});
+
+test('computeTrends: project cadence (count, streak, lastSeen)', () => {
+  const t = computeTrends(seed());
+  const byName = Object.fromEntries(t.projects.map(p => [p.name, p]));
+  assert.equal(byName['Diar.ia'].sprints, 3);
+  assert.equal(byName['Diar.ia'].streak, 3);
+  assert.equal(byName['Diar.ia'].lastSeen, '2026-01-19');
+  assert.equal(byName['Jandig'].sprints, 2);
+  assert.equal(byName['Jandig'].streak, 1); // absent in middle sprint, present in latest
+});
+
+test('computeTrends: empty repo yields zero count', () => {
+  const t = computeTrends(makeRepo());
+  assert.equal(t.count, 0);
+  assert.deepEqual(t.latest_carryover.on_my_mind, []);
+  assert.deepEqual(t.projects, []);
+});

--- a/bin/sprint.ts
+++ b/bin/sprint.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { inferCurrentPeriod, nextPeriod } from '../lib/period.js';
 import { loadLatestArchive } from '../lib/archive.js';
+import { computeTrends } from '../lib/trends.js';
 import { readWip, archiveWip } from '../lib/wip.js';
 import { filterAcceptedCalendarEvents, filterRelevantEmails, windowGithubEvents } from '../lib/filters.js';
 
@@ -76,6 +77,11 @@ async function main(): Promise<void> {
 
     case 'archive': {
       out(loadLatestArchive(repoPath()));
+      break;
+    }
+
+    case 'trends': {
+      out(computeTrends(repoPath()));
       break;
     }
 

--- a/lib/archive.ts
+++ b/lib/archive.ts
@@ -92,64 +92,77 @@ function parseInlineList(val: string): string[] {
   return inner.split(',').map(stripScalar).filter(s => s.length > 0);
 }
 
+export type FrontmatterValue = string | string[] | Record<string, string>;
+
 /**
- * Read the prior sprint's planning fields from leading YAML frontmatter, when
- * present. Returns null if there is no frontmatter or it carries none of the
- * planning keys — callers then fall back to parsePriorPlanning (prose) so old,
- * pre-frontmatter archives keep working. Deliberately a tiny, schema-specific
- * reader (block lists + one nested map + scalars); no YAML dependency.
+ * Parse leading YAML frontmatter into a generic object. Supports the subset the
+ * sprint docs use: scalars, block/inline lists of scalars, and one level of
+ * nested maps (e.g. health_goals, results_*). Returns null when there is no
+ * frontmatter block. Deliberately tiny and schema-shaped — no YAML dependency.
  */
-export function parseFrontmatter(content: string): PriorPlanning | null {
+export function parseFrontmatterObject(content: string): Record<string, FrontmatterValue> | null {
   const m = content.match(/^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/);
   if (!m) return null;
 
-  const result: PriorPlanning = { on_my_mind: [], on_hold: [], health_goals: {}, improvement_goals: [] };
-  const listFor: Record<string, string[]> = {
-    on_my_mind: result.on_my_mind,
-    on_hold: result.on_hold,
-    improvement_goals: result.improvement_goals,
-  };
-  let sawPlanningKey = false;
-
-  type Collector = { kind: 'list'; arr: string[] } | { kind: 'map'; obj: Record<string, string> } | null;
-  let collector: Collector = null;
+  const obj: Record<string, FrontmatterValue> = {};
+  let pendingKey: string | null = null; // empty-valued key awaiting indented children
 
   for (const rawLine of m[1].split(/\r?\n/)) {
     if (!rawLine.trim() || /^\s*#/.test(rawLine)) continue;
     const indent = rawLine.length - rawLine.replace(/^\s+/, '').length;
     const line = rawLine.trim();
 
-    if (collector && indent > 0) {
-      if (collector.kind === 'list' && line.startsWith('- ')) {
-        collector.arr.push(stripScalar(line.slice(2)));
-        continue;
-      }
-      if (collector.kind === 'map') {
+    if (pendingKey && indent > 0) {
+      if (line.startsWith('- ')) {
+        if (!Array.isArray(obj[pendingKey])) obj[pendingKey] = [];
+        (obj[pendingKey] as string[]).push(stripScalar(line.slice(2)));
+      } else {
         const kv = line.match(/^(.+?):\s*(.*)$/);
-        if (kv) collector.obj[stripScalar(kv[1])] = stripScalar(kv[2]);
-        continue;
+        if (kv) {
+          if (typeof obj[pendingKey] !== 'object' || Array.isArray(obj[pendingKey])) obj[pendingKey] = {};
+          (obj[pendingKey] as Record<string, string>)[stripScalar(kv[1])] = stripScalar(kv[2]);
+        }
       }
+      continue;
     }
 
     const top = indent === 0 ? rawLine.match(/^([A-Za-z_][\w-]*):[ \t]*(.*)$/) : null;
-    collector = null;
+    pendingKey = null;
     if (!top) continue;
 
     const key = top[1];
     const val = top[2].trim();
-
-    if (Object.prototype.hasOwnProperty.call(listFor, key)) {
-      sawPlanningKey = true;
-      const arr = listFor[key];
-      if (val.startsWith('[') && val.endsWith(']')) parseInlineList(val).forEach(x => arr.push(x));
-      else if (val === '') collector = { kind: 'list', arr };
-    } else if (key === 'health_goals') {
-      sawPlanningKey = true;
-      if (val === '') collector = { kind: 'map', obj: result.health_goals };
-    }
+    if (val === '') pendingKey = key;                       // children decide list vs map
+    else if (val === '[]') obj[key] = [];
+    else if (val === '{}') obj[key] = {};
+    else if (val.startsWith('[') && val.endsWith(']')) obj[key] = parseInlineList(val);
+    else obj[key] = stripScalar(val);
   }
 
-  return sawPlanningKey ? result : null;
+  return obj;
+}
+
+/**
+ * Read the prior sprint's planning fields from frontmatter. Returns null if
+ * there is no frontmatter or it carries none of the planning keys, so callers
+ * fall back to parsePriorPlanning (prose) for pre-frontmatter archives (#61).
+ */
+export function parseFrontmatter(content: string): PriorPlanning | null {
+  const obj = parseFrontmatterObject(content);
+  if (!obj) return null;
+  const planningKeys = ['on_my_mind', 'on_hold', 'improvement_goals', 'health_goals'];
+  if (!planningKeys.some(k => Object.prototype.hasOwnProperty.call(obj, k))) return null;
+
+  const arr = (v: FrontmatterValue | undefined): string[] => (Array.isArray(v) ? v : []);
+  const map = (v: FrontmatterValue | undefined): Record<string, string> =>
+    v && typeof v === 'object' && !Array.isArray(v) ? v : {};
+
+  return {
+    on_my_mind: arr(obj.on_my_mind),
+    on_hold: arr(obj.on_hold),
+    improvement_goals: arr(obj.improvement_goals),
+    health_goals: map(obj.health_goals),
+  };
 }
 
 export function loadLatestArchive(repoPath: string): ArchiveContext | null {

--- a/lib/trends.ts
+++ b/lib/trends.ts
@@ -1,0 +1,119 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { parseFrontmatterObject, FrontmatterValue } from './archive.js';
+
+export interface SprintRecord {
+  date: string;
+  review_period?: string;
+  plan_period?: string;
+  review_workdays?: number;
+  plan_workdays?: number;
+  projects: string[];
+  improvement_goals: string[];
+  health_goals: Record<string, string>;
+  on_my_mind: string[];
+  on_hold: string[];
+  // Results (filled at sprint-close, #65)
+  results_improvement?: Record<string, string>;
+  results_health?: Record<string, string>;
+  results_planned?: number;
+  results_shipped?: number;
+}
+
+export interface CarryoverAge { item: string; age: number; }
+export interface ProjectCadence { name: string; sprints: number; streak: number; lastSeen: string; }
+
+export interface Trends {
+  count: number;
+  sprints: SprintRecord[]; // ascending by date
+  latest_carryover: { on_my_mind: CarryoverAge[]; on_hold: CarryoverAge[] };
+  projects: ProjectCadence[];
+}
+
+const asArr = (v: FrontmatterValue | undefined): string[] => (Array.isArray(v) ? v : []);
+const asMap = (v: FrontmatterValue | undefined): Record<string, string> =>
+  v && typeof v === 'object' && !Array.isArray(v) ? v : {};
+const asNum = (v: FrontmatterValue | undefined): number | undefined => {
+  if (typeof v !== 'string') return undefined;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : undefined;
+};
+
+export function loadSprintRecords(repoPath: string): SprintRecord[] {
+  const archiveDir = path.join(repoPath, '.sprints', 'archive');
+  if (!fs.existsSync(archiveDir)) return [];
+
+  const records: SprintRecord[] = [];
+  const files = fs.readdirSync(archiveDir)
+    .filter(f => /^\d{4}-\d{2}-\d{2}\.md$/.test(f))
+    .sort(); // ascending by date (YYYY-MM-DD)
+
+  for (const f of files) {
+    const obj = parseFrontmatterObject(fs.readFileSync(path.join(archiveDir, f), 'utf8'));
+    if (!obj) continue; // pre-frontmatter archives are skipped from trends
+    records.push({
+      date: f.replace(/\.md$/, ''),
+      review_period: typeof obj.review_period === 'string' ? obj.review_period : undefined,
+      plan_period: typeof obj.plan_period === 'string' ? obj.plan_period : undefined,
+      review_workdays: asNum(obj.review_workdays),
+      plan_workdays: asNum(obj.plan_workdays),
+      projects: asArr(obj.projects),
+      improvement_goals: asArr(obj.improvement_goals),
+      health_goals: asMap(obj.health_goals),
+      on_my_mind: asArr(obj.on_my_mind),
+      on_hold: asArr(obj.on_hold),
+      results_improvement: 'results_improvement' in obj ? asMap(obj.results_improvement) : undefined,
+      results_health: 'results_health' in obj ? asMap(obj.results_health) : undefined,
+      results_planned: asNum(obj.results_planned),
+      results_shipped: asNum(obj.results_shipped),
+    });
+  }
+
+  return records;
+}
+
+/** For the latest sprint's items, count consecutive sprints (from latest back) containing each. */
+function consecutiveAge(records: SprintRecord[], pick: (r: SprintRecord) => string[]): CarryoverAge[] {
+  if (records.length === 0) return [];
+  return pick(records[records.length - 1]).map(item => {
+    let age = 0;
+    for (let i = records.length - 1; i >= 0; i--) {
+      if (pick(records[i]).includes(item)) age++;
+      else break;
+    }
+    return { item, age };
+  });
+}
+
+function projectCadence(records: SprintRecord[]): ProjectCadence[] {
+  const names = new Set<string>();
+  records.forEach(r => r.projects.forEach(p => names.add(p)));
+
+  const out: ProjectCadence[] = [];
+  for (const name of names) {
+    let sprints = 0;
+    let lastSeen = '';
+    for (const r of records) if (r.projects.includes(name)) { sprints++; lastSeen = r.date; }
+    let streak = 0;
+    for (let i = records.length - 1; i >= 0; i--) {
+      if (records[i].projects.includes(name)) streak++;
+      else break;
+    }
+    out.push({ name, sprints, streak, lastSeen });
+  }
+
+  return out.sort((a, b) => b.sprints - a.sprints || a.name.localeCompare(b.name));
+}
+
+export function computeTrends(repoPath: string): Trends {
+  const sprints = loadSprintRecords(repoPath);
+  return {
+    count: sprints.length,
+    sprints,
+    latest_carryover: {
+      on_my_mind: consecutiveAge(sprints, r => r.on_my_mind),
+      on_hold: consecutiveAge(sprints, r => r.on_hold),
+    },
+    projects: projectCadence(sprints),
+  };
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "check-sync": "node build.js --check",
     "install-skills": "bash bin/install-skills.sh",
     "check-skills": "bash bin/check-skills.sh",
-    "test": "node --test __tests__/parser.test.js __tests__/insert.test.js __tests__/skill-checks.test.js && node -r tsx/cjs --test __tests__/period.test.ts __tests__/archive.test.ts __tests__/wip.test.ts __tests__/filters.test.ts __tests__/cli.test.ts"
+    "test": "node --test __tests__/parser.test.js __tests__/insert.test.js __tests__/skill-checks.test.js && node -r tsx/cjs --test __tests__/period.test.ts __tests__/archive.test.ts __tests__/trends.test.ts __tests__/wip.test.ts __tests__/filters.test.ts __tests__/cli.test.ts"
   },
   "engines": {
     "node": ">=18"

--- a/sprint-close.md
+++ b/sprint-close.md
@@ -68,6 +68,10 @@ Mescle o rascunho com os novos dados:
 - Complete as seções narrativas (What could be improved, What will I commit) se ainda pendentes — em **estilo scrum** (bullets curtos e acionáveis; o "commit" é um action item concreto e rastreável, conforme `/sprint-start` PASSO 4b)
 - Ajuste o Sprint Planning se necessário
 - Mantenha o **frontmatter YAML** do topo em sincronia com os valores finais do Planning (`improvement_goals`, `health_goals`, `on_my_mind`, `on_hold`) — é o que o próximo `/sprint-start` lê via `bin/sprint.ts archive`
+- Ao preencher os `[PENDING]` da Retro, grave também os **resultados no frontmatter** (lidos pelo `bin/sprint.ts trends` e pelo dashboard Obsidian):
+  - `results_improvement:` — mapa meta→resultado da tabela "Last week's improvement goals" (ex.: `Stop working by 9 PM: "3/5"`)
+  - `results_health:` — mapa chave→valor real da tabela Health (ex.: `Meditate: "4/4"`, `Sleep Score: "78"`)
+  - opcional: `results_planned: N` e `results_shipped: N` (Outcomes planejados vs. entregues)
 
 **Ao adicionar Outputs/Outcomes**, siga as mesmas regras do `/sprint-start`:
 - **Output language is English.** Outcomes, Outputs, narrativas e tabelas em inglês — traduzir qualquer dado-fonte em português.

--- a/sprint-start.md
+++ b/sprint-start.md
@@ -40,6 +40,14 @@ Aplique `improvement_goals` e `health_goals` no PASSO 4b (avaliação do sprint 
 - Mover de **On hold** para **Projects Priority** se: bloqueador respondeu por email/calendário OU tarefas reativadas em TickTick.
 - Caso contrário, preservar exatamente como veio no JSON.
 
+**Tendências (histórico de todos os sprints).** Rode também — o frontmatter de cada arquivo alimenta isso:
+
+```bash
+node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts trends --repo <<REPO_PATH>>
+```
+
+Retorna `sprints[]` (série ascendente: períodos, projetos, goals, results), `latest_carryover` (cada item de On my mind / On hold com `age` = nº de sprints consecutivos) e `projects[]` (cadência: `sprints`, `streak`, `lastSeen`). Aplique no PASSO 4b (contexto de tendência ao lado dos resultados) e no PASSO 4c (calibração de metas, envelhecimento de carryover, cadência de projeto).
+
 ---
 
 ## PASSO 2: Coleta automática de dados
@@ -220,6 +228,7 @@ Após confirmação do Review, gere e exiba **apenas o Sprint Retrospective**. A
   - "Health goals" → use as chaves de `health_goals{}` exatamente como vieram, com a meta no denominador (ex.: `{"Meditate":"7 days"}` → linha `| Meditate | **[PENDING] / 7 days** |`).
   - Se o archive for `null` (primeiro uso) OU as listas vierem vazias, mantenha as 3 linhas placeholder com `[PENDING] / ?` e adicione nota: "(archive sem metas anteriores — preencher manualmente)".
 - Result column: marque com `[PENDING] / X` quando não conseguir derivar dos dados; o usuário preenche.
+- Se houver `trends` (PASSO 1b), anexe o contexto de tendência ao lado de cada resultado (ex.: `Meditate: 1 → 2 → 4`) — uma meta de improvement que recorre há vários sprints sem evolução é sinal para a seção "What could be improved?".
 - Rascunhar as 3 seções narrativas agora — não deixar como [PENDING]
 - Cada seção narrativa tem exatamente 1 bullet
 - "What did I do well?" foca em melhorias no sistema de trabalho
@@ -282,8 +291,9 @@ Após confirmação da Retro, gere e exiba **apenas o Sprint Planning**. All gen
 - Usar seção "Projects Priority" (não "Priority order")
 - **Improvements**: por default carregue `improvement_goals[]` do archive (mesmas labels da Retro do PASSO 4b — espelham o ciclo). Só sugira mudanças se o "What will I commit to improving?" da Retro propuser explicitamente uma nova meta — nesse caso, substitua a linha correspondente.
 - **Health goals**: por default carregue as mesmas chaves de `health_goals{}` do archive com as mesmas metas. Só ajuste se o Retrospective sinalizar que vale puxar a meta (ex.: Sleep Score atingido 3 sprints seguidos → propor +2). Sempre propor números concretos — nunca deixar [PENDING].
-- "On my mind" e "On hold": preservar os itens do sprint anterior se não houver indicação de mudança
+- "On my mind" e "On hold": preservar os itens do sprint anterior se não houver indicação de mudança. Com `trends`, anexe a idade (ex.: "Job Hunt — 5 sprints"): item com `age ≥ 3` → propor escalar, mudar abordagem ou dropar, não apenas recarregar
 - Outcomes: propor um resultado concreto por projeto ativo — o que tornaria o sprint bem-sucedido para aquele projeto
+- **Calibrar pela tendência** (`trends`, não só o último sprint): meta batida em `streak` de sprints → propor subir; meta recorrente sem evolução → trocar a forma. Projeto com `streak` alto e sem entregar pode estar travado — rever prioridade ou mover para On Hold
 
 **Detecção de projetos bloqueados em terceiros:**
 


### PR DESCRIPTION
Closes #64. Closes #65. Builds on #61 (frontmatter-as-data).

## #64 — trends read + planning wiring
- **`lib/trends.ts`** — `loadSprintRecords()` reads every `.sprints/archive/*.md` frontmatter into a date-sorted series; `computeTrends()` adds **consecutive carryover age** (how many sprints in a row an `on_my_mind`/`on_hold` item has appeared) and **project cadence** (sprints / streak / lastSeen).
- **`bin/sprint.ts trends`** — new subcommand returning `{ count, sprints[], latest_carryover, projects[] }`.
- **`sprint-start.md`** — PASSO 1b runs `trends`; PASSO 4b uses it for trend context next to results; PASSO 4c uses it for goal calibration, carryover aging (`age ≥ 3` → escalate/change/drop), and project-cadence flags.

On the real backfilled data it already surfaces signals: *Job Hunt — awaiting Google* has carried **5 sprints**, Diar.ia has a 5-sprint streak, and one project appears spelled three ways (normalization hint).

## #65 — results in frontmatter
- **`parseFrontmatterObject()`** — generalized the reader to a generic one-level YAML object (scalars / block+inline lists / nested maps), still dependency-free. `parseFrontmatter()` is refactored onto it (behavior preserved; prose fallback intact).
- Reads `results_improvement`, `results_health` (maps) and `results_planned` / `results_shipped` (scalars).
- **`sprint-close.md`** — emit `results_*` when filling the Retro `[PENDING]`s.
- Dashboard gains **goal hit-rate** + **planned-vs-shipped** panels (in the gitignored vault).

## Tests
`__tests__/trends.test.ts` (records, carryover age, cadence, results) + `parseFrontmatterObject` cases; wired into `npm test`. **146 tests green**, `check-skills.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)