### PR TITLE
fix: address code-review findings on trends/frontmatter

### DIFF
--- a/__tests__/archive.test.ts
+++ b/__tests__/archive.test.ts
@@ -270,3 +270,23 @@ body
 test('parseFrontmatterObject: returns null without frontmatter', () => {
   assert.equal(parseFrontmatterObject('# no frontmatter\n'), null);
 });
+
+test('parseFrontmatter: a bare empty planning key still registers (not null)', () => {
+  // Regression (#64 review): the generic rewrite must register `on_my_mind:`
+  // with no children, so frontmatter stays authoritative over stale prose.
+  const r = parseFrontmatter('---\ntype: sprint\non_my_mind:\n---\n');
+  assert.ok(r, 'bare empty planning key must keep frontmatter authoritative');
+  assert.deepEqual(r.on_my_mind, []);
+});
+
+test('parseFrontmatterObject: a populated list ignores a stray map child (no flip)', () => {
+  const o = parseFrontmatterObject('---\non_my_mind:\n  - First\n  stray: x\n---\n');
+  assert.ok(o);
+  assert.deepEqual(o.on_my_mind, ['First']);
+});
+
+test('parseFrontmatterObject: inline list respects quoted commas', () => {
+  const o = parseFrontmatterObject('---\nprojects: [Diar.ia, "Bar, Inc", Jandig]\n---\n');
+  assert.ok(o);
+  assert.deepEqual(o.projects, ['Diar.ia', 'Bar, Inc', 'Jandig']);
+});

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -81,6 +81,23 @@ test('cli: archive returns parsed sections from latest archive', () => {
   assert.equal(json.health_goals['Meditate'], '7 days');
 });
 
+// ──────────────────────────── trends ─────────────────────────────
+
+test('cli: trends aggregates archives with carryover age + project cadence', () => {
+  const repo = tmpRepo();
+  const fm = (omm: string) => `---\ntype: sprint\nprojects:\n  - Diar.ia\non_my_mind:\n  - ${omm}\non_hold: []\n---\nbody\n`;
+  fs.writeFileSync(path.join(repo, '.sprints', 'archive', '2026-04-20.md'), fm('Carryover X'));
+  fs.writeFileSync(path.join(repo, '.sprints', 'archive', '2026-04-27.md'), fm('Carryover X'));
+  const r = run(['trends', '--repo', repo]);
+  assert.equal(r.status, 0, r.stderr);
+  const json = JSON.parse(r.stdout);
+  assert.equal(json.sprints.length, 2);
+  assert.equal(json.latest_carryover.on_my_mind[0].item, 'Carryover X');
+  assert.equal(json.latest_carryover.on_my_mind[0].age, 2);
+  const diaria = json.projects.find((p: { name: string }) => p.name === 'Diar.ia');
+  assert.equal(diaria.streak, 2);
+});
+
 // ──────────────────────────── read-wip + archive-wip ─────────────
 
 test('cli: read-wip exits 1 when sprint-wip.md is absent', () => {

--- a/__tests__/trends.test.ts
+++ b/__tests__/trends.test.ts
@@ -1,13 +1,17 @@
-import { test } from 'node:test';
+import { test, after } from 'node:test';
 import assert from 'node:assert/strict';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { loadSprintRecords, computeTrends } from '../lib/trends.js';
 
+const tmpDirs: string[] = [];
+after(() => { for (const d of tmpDirs) fs.rmSync(d, { recursive: true, force: true }); });
+
 function makeRepo(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 're-plan-trends-'));
   fs.mkdirSync(path.join(dir, '.sprints', 'archive'), { recursive: true });
+  tmpDirs.push(dir);
   return dir;
 }
 function writeArchive(repo: string, date: string, content: string): void {
@@ -119,9 +123,41 @@ test('computeTrends: project cadence (count, streak, lastSeen)', () => {
   assert.equal(byName['Jandig'].streak, 1); // absent in middle sprint, present in latest
 });
 
-test('computeTrends: empty repo yields zero count', () => {
+test('computeTrends: empty repo yields no sprints', () => {
   const t = computeTrends(makeRepo());
-  assert.equal(t.count, 0);
+  assert.equal(t.sprints.length, 0);
   assert.deepEqual(t.latest_carryover.on_my_mind, []);
   assert.deepEqual(t.projects, []);
+});
+
+test('computeTrends: dedupes duplicate carryover items', () => {
+  const r = makeRepo();
+  writeArchive(r, '2026-02-02', `---\non_my_mind:\n  - X\n  - X\non_hold: []\n---\nbody\n`);
+  const t = computeTrends(r);
+  assert.equal(t.latest_carryover.on_my_mind.length, 1);
+  assert.equal(t.latest_carryover.on_my_mind[0].item, 'X');
+});
+
+test('loadSprintRecords: empty results scalar is undefined, not 0', () => {
+  const r = makeRepo();
+  writeArchive(r, '2026-02-02', `---\nresults_planned: ""\nimprovement_goals: []\n---\nbody\n`);
+  assert.equal(loadSprintRecords(r)[0].results_planned, undefined);
+});
+
+test('loadSprintRecords: includes pre-frontmatter (prose) archives via fallback', () => {
+  const r = makeRepo();
+  writeArchive(r, '2026-02-01', `---\non_my_mind:\n  - X\non_hold: []\n---\nbody\n`);
+  writeArchive(r, '2026-02-08', `## On my mind\nProseItem\n## On hold\n`);
+  const recs = loadSprintRecords(r);
+  assert.equal(recs.length, 2);
+  assert.equal(recs[1].date, '2026-02-08');
+  assert.deepEqual(recs[1].on_my_mind, ['ProseItem']);
+});
+
+test('loadSprintRecords: falls back to legacy sprint-final.md when no dated archives', () => {
+  const r = makeRepo();
+  fs.writeFileSync(path.join(r, '.sprints', 'sprint-final.md'), `---\non_my_mind:\n  - L\non_hold: []\n---\nbody\n`);
+  const recs = loadSprintRecords(r);
+  assert.equal(recs.length, 1);
+  assert.deepEqual(recs[0].on_my_mind, ['L']);
 });

--- a/lib/archive.ts
+++ b/lib/archive.ts
@@ -10,17 +10,27 @@ export interface ArchiveContext {
   improvement_goals: string[];
 }
 
+const ARCHIVE_FILE_RE = /^\d{4}-\d{2}-\d{2}\.md$/;
+
+/** Dated archive files (full paths) sorted ascending by date. Excludes directories. */
+export function archiveFiles(repoPath: string): string[] {
+  const dir = path.join(repoPath, '.sprints', 'archive');
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir, { withFileTypes: true })
+    .filter(d => d.isFile() && ARCHIVE_FILE_RE.test(d.name))
+    .map(d => d.name)
+    .sort()
+    .map(name => path.join(dir, name));
+}
+
+export function legacyArchivePath(repoPath: string): string {
+  return path.join(repoPath, '.sprints', 'sprint-final.md');
+}
+
 export function latestArchivePath(repoPath: string): string | null {
-  const archiveDir = path.join(repoPath, '.sprints', 'archive');
-  const legacy = path.join(repoPath, '.sprints', 'sprint-final.md');
-
-  if (fs.existsSync(archiveDir)) {
-    const files = fs.readdirSync(archiveDir)
-      .filter(f => /^\d{4}-\d{2}-\d{2}\.md$/.test(f))
-      .sort();
-    if (files.length > 0) return path.join(archiveDir, files[files.length - 1]);
-  }
-
+  const files = archiveFiles(repoPath);
+  if (files.length > 0) return files[files.length - 1];
+  const legacy = legacyArchivePath(repoPath);
   return fs.existsSync(legacy) ? legacy : null;
 }
 
@@ -86,13 +96,33 @@ function stripScalar(s: string): string {
   return t;
 }
 
+/** Split an inline `[a, "b, c", d]` list on top-level commas (quote-aware). */
 function parseInlineList(val: string): string[] {
-  const inner = val.slice(1, -1).trim();
-  if (!inner) return [];
-  return inner.split(',').map(stripScalar).filter(s => s.length > 0);
+  const inner = val.slice(1, -1);
+  const items: string[] = [];
+  let buf = '';
+  let quote = '';
+  for (const ch of inner) {
+    if (quote) { buf += ch; if (ch === quote) quote = ''; }
+    else if (ch === '"' || ch === "'") { quote = ch; buf += ch; }
+    else if (ch === ',') { items.push(buf); buf = ''; }
+    else buf += ch;
+  }
+  items.push(buf);
+  return items.map(stripScalar).filter(s => s.length > 0);
 }
 
 export type FrontmatterValue = string | string[] | Record<string, string>;
+
+// Shared coercions — one home so lib/archive.ts and lib/trends.ts can't diverge.
+export const fmArray = (v?: FrontmatterValue): string[] => (Array.isArray(v) ? v : []);
+export const fmMap = (v?: FrontmatterValue): Record<string, string> =>
+  v && typeof v === 'object' && !Array.isArray(v) ? v : {};
+export const fmNumber = (v?: FrontmatterValue): number | undefined => {
+  if (typeof v !== 'string' || v.trim() === '') return undefined; // '' is "unknown", not 0
+  const n = Number(v);
+  return Number.isFinite(n) ? n : undefined;
+};
 
 /**
  * Parse leading YAML frontmatter into a generic object. Supports the subset the
@@ -105,7 +135,7 @@ export function parseFrontmatterObject(content: string): Record<string, Frontmat
   if (!m) return null;
 
   const obj: Record<string, FrontmatterValue> = {};
-  let pendingKey: string | null = null; // empty-valued key awaiting indented children
+  let pendingKey: string | null = null; // key awaiting indented children; seeded to [] so it registers
 
   for (const rawLine of m[1].split(/\r?\n/)) {
     if (!rawLine.trim() || /^\s*#/.test(rawLine)) continue;
@@ -113,14 +143,18 @@ export function parseFrontmatterObject(content: string): Record<string, Frontmat
     const line = rawLine.trim();
 
     if (pendingKey && indent > 0) {
+      const cur = obj[pendingKey];
       if (line.startsWith('- ')) {
-        if (!Array.isArray(obj[pendingKey])) obj[pendingKey] = [];
-        (obj[pendingKey] as string[]).push(stripScalar(line.slice(2)));
+        if (Array.isArray(cur)) cur.push(stripScalar(line.slice(2)));
+        // a map was already started under this key → ignore a stray list item
       } else {
         const kv = line.match(/^(.+?):\s*(.*)$/);
         if (kv) {
-          if (typeof obj[pendingKey] !== 'object' || Array.isArray(obj[pendingKey])) obj[pendingKey] = {};
-          (obj[pendingKey] as Record<string, string>)[stripScalar(kv[1])] = stripScalar(kv[2]);
+          const k = stripScalar(kv[1]);
+          const v = stripScalar(kv[2]);
+          if (Array.isArray(cur) && cur.length === 0) obj[pendingKey] = { [k]: v }; // empty seed → first child makes it a map
+          else if (cur && typeof cur === 'object' && !Array.isArray(cur)) (cur as Record<string, string>)[k] = v;
+          // a populated list was already started → ignore a stray map child (don't flip/drop)
         }
       }
       continue;
@@ -132,7 +166,7 @@ export function parseFrontmatterObject(content: string): Record<string, Frontmat
 
     const key = top[1];
     const val = top[2].trim();
-    if (val === '') pendingKey = key;                       // children decide list vs map
+    if (val === '') { pendingKey = key; obj[key] = []; } // register the key; a child may convert it to a map
     else if (val === '[]') obj[key] = [];
     else if (val === '{}') obj[key] = {};
     else if (val.startsWith('[') && val.endsWith(']')) obj[key] = parseInlineList(val);
@@ -153,15 +187,11 @@ export function parseFrontmatter(content: string): PriorPlanning | null {
   const planningKeys = ['on_my_mind', 'on_hold', 'improvement_goals', 'health_goals'];
   if (!planningKeys.some(k => Object.prototype.hasOwnProperty.call(obj, k))) return null;
 
-  const arr = (v: FrontmatterValue | undefined): string[] => (Array.isArray(v) ? v : []);
-  const map = (v: FrontmatterValue | undefined): Record<string, string> =>
-    v && typeof v === 'object' && !Array.isArray(v) ? v : {};
-
   return {
-    on_my_mind: arr(obj.on_my_mind),
-    on_hold: arr(obj.on_hold),
-    improvement_goals: arr(obj.improvement_goals),
-    health_goals: map(obj.health_goals),
+    on_my_mind: fmArray(obj.on_my_mind),
+    on_hold: fmArray(obj.on_hold),
+    improvement_goals: fmArray(obj.improvement_goals),
+    health_goals: fmMap(obj.health_goals),
   };
 }
 

--- a/lib/trends.ts
+++ b/lib/trends.ts
@@ -1,6 +1,14 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { parseFrontmatterObject, FrontmatterValue } from './archive.js';
+import {
+  archiveFiles,
+  legacyArchivePath,
+  parseFrontmatterObject,
+  parsePriorPlanning,
+  fmArray,
+  fmMap,
+  fmNumber,
+} from './archive.js';
 
 export interface SprintRecord {
   date: string;
@@ -24,65 +32,75 @@ export interface CarryoverAge { item: string; age: number; }
 export interface ProjectCadence { name: string; sprints: number; streak: number; lastSeen: string; }
 
 export interface Trends {
-  count: number;
   sprints: SprintRecord[]; // ascending by date
   latest_carryover: { on_my_mind: CarryoverAge[]; on_hold: CarryoverAge[] };
   projects: ProjectCadence[];
 }
 
-const asArr = (v: FrontmatterValue | undefined): string[] => (Array.isArray(v) ? v : []);
-const asMap = (v: FrontmatterValue | undefined): Record<string, string> =>
-  v && typeof v === 'object' && !Array.isArray(v) ? v : {};
-const asNum = (v: FrontmatterValue | undefined): number | undefined => {
-  if (typeof v !== 'string') return undefined;
-  const n = Number(v);
-  return Number.isFinite(n) ? n : undefined;
-};
+/** Count consecutive items from the end that satisfy `pred`, stopping at the first miss. */
+function countFromEnd<T>(items: T[], pred: (x: T) => boolean): number {
+  let n = 0;
+  for (let i = items.length - 1; i >= 0; i--) {
+    if (pred(items[i])) n++;
+    else break;
+  }
+  return n;
+}
 
 export function loadSprintRecords(repoPath: string): SprintRecord[] {
-  const archiveDir = path.join(repoPath, '.sprints', 'archive');
-  if (!fs.existsSync(archiveDir)) return [];
+  let paths = archiveFiles(repoPath);
+  if (paths.length === 0) {
+    const legacy = legacyArchivePath(repoPath);
+    if (fs.existsSync(legacy)) paths = [legacy]; // match loadLatestArchive's legacy fallback
+  }
 
   const records: SprintRecord[] = [];
-  const files = fs.readdirSync(archiveDir)
-    .filter(f => /^\d{4}-\d{2}-\d{2}\.md$/.test(f))
-    .sort(); // ascending by date (YYYY-MM-DD)
+  for (const fp of paths) {
+    const content = fs.readFileSync(fp, 'utf8');
+    const date = path.basename(fp).replace(/\.md$/, '');
+    const obj = parseFrontmatterObject(content);
 
-  for (const f of files) {
-    const obj = parseFrontmatterObject(fs.readFileSync(path.join(archiveDir, f), 'utf8'));
-    if (!obj) continue; // pre-frontmatter archives are skipped from trends
-    records.push({
-      date: f.replace(/\.md$/, ''),
-      review_period: typeof obj.review_period === 'string' ? obj.review_period : undefined,
-      plan_period: typeof obj.plan_period === 'string' ? obj.plan_period : undefined,
-      review_workdays: asNum(obj.review_workdays),
-      plan_workdays: asNum(obj.plan_workdays),
-      projects: asArr(obj.projects),
-      improvement_goals: asArr(obj.improvement_goals),
-      health_goals: asMap(obj.health_goals),
-      on_my_mind: asArr(obj.on_my_mind),
-      on_hold: asArr(obj.on_hold),
-      results_improvement: 'results_improvement' in obj ? asMap(obj.results_improvement) : undefined,
-      results_health: 'results_health' in obj ? asMap(obj.results_health) : undefined,
-      results_planned: asNum(obj.results_planned),
-      results_shipped: asNum(obj.results_shipped),
-    });
+    if (obj) {
+      records.push({
+        date,
+        review_period: typeof obj.review_period === 'string' ? obj.review_period : undefined,
+        plan_period: typeof obj.plan_period === 'string' ? obj.plan_period : undefined,
+        review_workdays: fmNumber(obj.review_workdays),
+        plan_workdays: fmNumber(obj.plan_workdays),
+        projects: fmArray(obj.projects),
+        improvement_goals: fmArray(obj.improvement_goals),
+        health_goals: fmMap(obj.health_goals),
+        on_my_mind: fmArray(obj.on_my_mind),
+        on_hold: fmArray(obj.on_hold),
+        results_improvement: 'results_improvement' in obj ? fmMap(obj.results_improvement) : undefined,
+        results_health: 'results_health' in obj ? fmMap(obj.results_health) : undefined,
+        results_planned: fmNumber(obj.results_planned),
+        results_shipped: fmNumber(obj.results_shipped),
+      });
+    } else {
+      // Pre-frontmatter (prose) archive: keep it in the series via the prose
+      // parser so gaps and "latest" stay consistent with loadLatestArchive,
+      // instead of silently dropping it (which over-counts age/streak).
+      const p = parsePriorPlanning(content);
+      records.push({
+        date,
+        projects: [],
+        improvement_goals: p.improvement_goals,
+        health_goals: p.health_goals,
+        on_my_mind: p.on_my_mind,
+        on_hold: p.on_hold,
+      });
+    }
   }
 
   return records;
 }
 
-/** For the latest sprint's items, count consecutive sprints (from latest back) containing each. */
+/** For the latest sprint's (deduped) items, count consecutive sprints from latest back. */
 function consecutiveAge(records: SprintRecord[], pick: (r: SprintRecord) => string[]): CarryoverAge[] {
   if (records.length === 0) return [];
-  return pick(records[records.length - 1]).map(item => {
-    let age = 0;
-    for (let i = records.length - 1; i >= 0; i--) {
-      if (pick(records[i]).includes(item)) age++;
-      else break;
-    }
-    return { item, age };
-  });
+  const latest = [...new Set(pick(records[records.length - 1]))];
+  return latest.map(item => ({ item, age: countFromEnd(records, r => pick(r).includes(item)) }));
 }
 
 function projectCadence(records: SprintRecord[]): ProjectCadence[] {
@@ -94,12 +112,7 @@ function projectCadence(records: SprintRecord[]): ProjectCadence[] {
     let sprints = 0;
     let lastSeen = '';
     for (const r of records) if (r.projects.includes(name)) { sprints++; lastSeen = r.date; }
-    let streak = 0;
-    for (let i = records.length - 1; i >= 0; i--) {
-      if (records[i].projects.includes(name)) streak++;
-      else break;
-    }
-    out.push({ name, sprints, streak, lastSeen });
+    out.push({ name, sprints, streak: countFromEnd(records, r => r.projects.includes(name)), lastSeen });
   }
 
   return out.sort((a, b) => b.sprints - a.sprints || a.name.localeCompare(b.name));
@@ -108,7 +121,6 @@ function projectCadence(records: SprintRecord[]): ProjectCadence[] {
 export function computeTrends(repoPath: string): Trends {
   const sprints = loadSprintRecords(repoPath);
   return {
-    count: sprints.length,
     sprints,
     latest_carryover: {
       on_my_mind: consecutiveAge(sprints, r => r.on_my_mind),

--- a/sprint-start.md
+++ b/sprint-start.md
@@ -293,7 +293,7 @@ Após confirmação da Retro, gere e exiba **apenas o Sprint Planning**. All gen
 - **Health goals**: por default carregue as mesmas chaves de `health_goals{}` do archive com as mesmas metas. Só ajuste se o Retrospective sinalizar que vale puxar a meta (ex.: Sleep Score atingido 3 sprints seguidos → propor +2). Sempre propor números concretos — nunca deixar [PENDING].
 - "On my mind" e "On hold": preservar os itens do sprint anterior se não houver indicação de mudança. Com `trends`, anexe a idade (ex.: "Job Hunt — 5 sprints"): item com `age ≥ 3` → propor escalar, mudar abordagem ou dropar, não apenas recarregar
 - Outcomes: propor um resultado concreto por projeto ativo — o que tornaria o sprint bem-sucedido para aquele projeto
-- **Calibrar pela tendência** (`trends`, não só o último sprint): meta batida em `streak` de sprints → propor subir; meta recorrente sem evolução → trocar a forma. Projeto com `streak` alto e sem entregar pode estar travado — rever prioridade ou mover para On Hold
+- **Calibrar pela tendência** (`trends`, não só o último sprint): meta cujos resultados melhoram ao longo da série (`sprints[].results_*`) → propor subir; meta que recorre há vários sprints sem evolução → trocar a forma. Projeto com `streak` alto (campo de `projects[]`) e sem entregar pode estar travado — rever prioridade ou mover para On Hold
 
 **Detecção de projetos bloqueados em terceiros:**
 


### PR DESCRIPTION
Fixes the 15 findings from the extra-high code review of #66 (trends + results-in-frontmatter). No new issue — follow-up hardening.

## Correctness
- **Bare empty planning key** (`on_my_mind:` with no children) now registers, so frontmatter stays authoritative instead of falling back to stale prose.
- **Mixed list/map children** no longer flip the container type and drop collected data.
- **parseInlineList** is quote-aware — commas inside `"…"` no longer split items.
- **Archive listing** uses `withFileTypes` to exclude directories (no uncaught EISDIR).
- **Empty numeric scalar** (`results_planned: ""`) → `undefined`, not `0`.
- **trends** now includes pre-frontmatter (prose) archives and the legacy `sprint-final.md`, so its series matches `loadLatestArchive` — fixes gap-collapse over-counting `age`/`streak` and the "latest sprint" divergence between the `trends` and `archive` commands.
- **Carryover dedup**: duplicate items in the latest sprint no longer produce duplicate `latest_carryover` entries.
- **Skill wording**: `streak` is documented as a `projects[]` field; goals calibrate off the results series.

## Cleanup
- Shared `fmArray`/`fmMap`/`fmNumber` coercions, `archiveFiles()` listing, and a `countFromEnd()` helper — deduped across `archive.ts` and `trends.ts`. Dropped the redundant `Trends.count`.

## Tests
Regression case per correctness fix, an **end-to-end CLI `trends`** test, and teardown for the trends temp dirs. **154 tests green**, `check-skills` passes, and `trends` on real data is unchanged (Job Hunt age 5, Diar.ia streak 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)