### PR TITLE
fix: period cadence (#68), project aliases (#69), goal-encoding (#70)

### DIFF
--- a/__tests__/archive.test.ts
+++ b/__tests__/archive.test.ts
@@ -290,3 +290,11 @@ test('parseFrontmatterObject: inline list respects quoted commas', () => {
   assert.ok(o);
   assert.deepEqual(o.projects, ['Diar.ia', 'Bar, Inc', 'Jandig']);
 });
+
+test('loadLatestArchive: normalizes health-goal encoding (>= → ≥) (#70)', () => {
+  const repo = makeTmpRepo();
+  writeArchive(repo, '2026-03-01', '---\nhealth_goals:\n  Sleep Score: "avg >= 80"\non_hold: []\n---\n');
+  const r = loadLatestArchive(repo);
+  assert.ok(r);
+  assert.equal(r.health_goals['Sleep Score'], 'avg ≥ 80');
+});

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -33,16 +33,16 @@ function tmpRepo(): string {
 // ──────────────────────────── period ────────────────────────────
 
 test('cli: period --today returns current+next JSON to stdout', () => {
-  const r = run(['period', '--today', '2026-05-04']);
+  const r = run(['period', '--today', '2026-05-08']); // a Friday (last-workday cadence)
   assert.equal(r.status, 0, r.stderr);
   const json = JSON.parse(r.stdout);
-  // Mon 4/May → last Sun = 3/May → Mon–Sun week 27/Apr–3/May (May 1 holiday → 4 workdays)
-  assert.equal(json.current.start, '2026-04-27');
-  assert.equal(json.current.end, '2026-05-03');
-  assert.equal(json.current.workdays, 4);
-  // Next: Mon 4/May–Sun 10/May (5 workdays)
-  assert.equal(json.next.start, '2026-05-04');
-  assert.equal(json.next.end, '2026-05-10');
+  // Fri 8/May → in-progress week Mon 4–Sun 10/May (5 workdays), not the previous one (#68)
+  assert.equal(json.current.start, '2026-05-04');
+  assert.equal(json.current.end, '2026-05-10');
+  assert.equal(json.current.workdays, 5);
+  // Next: Mon 11–Sun 17/May (5 workdays)
+  assert.equal(json.next.start, '2026-05-11');
+  assert.equal(json.next.end, '2026-05-17');
   assert.equal(json.next.workdays, 5);
 });
 

--- a/__tests__/period.test.ts
+++ b/__tests__/period.test.ts
@@ -9,45 +9,45 @@ function d(iso: string): Date {
 
 // inferCurrentPeriod — Mon–Sun fixed-week model
 
-test('inferCurrentPeriod: Tuesday → closes previous Mon–Sun week', () => {
-  // Tue 5/May → last Sun = 3/May → start = 27/Apr; May 1 is holiday
+test('inferCurrentPeriod: Tuesday → reviews the week containing today', () => {
+  // Tue 5/May → this week's Sunday = 10/May → start = 4/May; no holidays
   const r = inferCurrentPeriod(d('2026-05-05'));
-  assert.equal(r.start, '2026-04-27');
-  assert.equal(r.end, '2026-05-03');
-  assert.equal(r.workdays, 4);
-  assert.deepEqual(r.holidays, ['2026-05-01']);
+  assert.equal(r.start, '2026-05-04');
+  assert.equal(r.end, '2026-05-10');
+  assert.equal(r.workdays, 5);
+  assert.deepEqual(r.holidays, []);
 });
 
-test('inferCurrentPeriod: Friday → closes previous Mon–Sun week (current still in progress)', () => {
-  // Fri 8/May → last Sun = 3/May → start = 27/Apr; May 1 is holiday
+test('inferCurrentPeriod: Friday (last workday) → reviews the in-progress week, not the previous one (#68)', () => {
+  // Fri 8/May → this week's Sunday = 10/May → start = 4/May; no holidays
   const r = inferCurrentPeriod(d('2026-05-08'));
-  assert.equal(r.start, '2026-04-27');
-  assert.equal(r.end, '2026-05-03');
-  assert.equal(r.workdays, 4);
-  assert.deepEqual(r.holidays, ['2026-05-01']);
+  assert.equal(r.start, '2026-05-04');
+  assert.equal(r.end, '2026-05-10');
+  assert.equal(r.workdays, 5);
+  assert.deepEqual(r.holidays, []);
 });
 
-test('inferCurrentPeriod: Saturday → closes previous Mon–Sun week (current still in progress)', () => {
-  // Sat 9/May → last Sun = 3/May → start = 27/Apr; May 1 is holiday
+test('inferCurrentPeriod: Saturday → reviews the week containing today', () => {
+  // Sat 9/May → this week's Sunday = 10/May → start = 4/May; no holidays
   const r = inferCurrentPeriod(d('2026-05-09'));
-  assert.equal(r.start, '2026-04-27');
-  assert.equal(r.end, '2026-05-03');
-  assert.equal(r.workdays, 4);
-  assert.deepEqual(r.holidays, ['2026-05-01']);
+  assert.equal(r.start, '2026-05-04');
+  assert.equal(r.end, '2026-05-10');
+  assert.equal(r.workdays, 5);
+  assert.deepEqual(r.holidays, []);
 });
 
 test('inferCurrentPeriod: range spanning year boundary picks up Jan 1 holiday', () => {
-  // Wed 6/Jan/2027 → last Sun = 3/Jan/2027 → start = 28/Dec/2026
-  // Jan 1, 2027 is in range → 4 workdays (Mon Dec 28, Tue 29, Wed 30, Thu 31, [Fri Jan 1 holiday])
-  const r = inferCurrentPeriod(d('2027-01-06'));
+  // Wed 30/Dec/2026 → this week's Sunday = 3/Jan/2027 → start = 28/Dec/2026
+  // Jan 1, 2027 is in range → 4 workdays (Mon Dec 28 … Thu 31, [Fri Jan 1 holiday])
+  const r = inferCurrentPeriod(d('2026-12-30'));
   assert.equal(r.start, '2026-12-28');
   assert.equal(r.end, '2027-01-03');
   assert.equal(r.workdays, 4);
   assert.deepEqual(r.holidays, ['2027-01-01']);
 });
 
-test('inferCurrentPeriod: Sunday → closes the week that ended today', () => {
-  // Sun 10/May → last Sun = 10/May → start = 4/May; no holidays
+test('inferCurrentPeriod: Sunday → reviews the week ending today', () => {
+  // Sun 10/May → this week's Sunday = 10/May → start = 4/May; no holidays
   const r = inferCurrentPeriod(d('2026-05-10'));
   assert.equal(r.start, '2026-05-04');
   assert.equal(r.end, '2026-05-10');
@@ -55,27 +55,27 @@ test('inferCurrentPeriod: Sunday → closes the week that ended today', () => {
   assert.deepEqual(r.holidays, []);
 });
 
-test('inferCurrentPeriod: Monday → closes previous Mon–Sun week (new week just started)', () => {
-  // Mon 4/May → last Sun = 3/May → start = 27/Apr; May 1 is holiday
+test('inferCurrentPeriod: Monday → reviews the week just started (containing today)', () => {
+  // Mon 4/May → this week's Sunday = 10/May → start = 4/May; no holidays
   const r = inferCurrentPeriod(d('2026-05-04'));
-  assert.equal(r.start, '2026-04-27');
-  assert.equal(r.end, '2026-05-03');
-  assert.equal(r.workdays, 4);
-  assert.deepEqual(r.holidays, ['2026-05-01']);
-});
-
-test('inferCurrentPeriod: week with no holidays has 5 workdays', () => {
-  // Thu 14/May → last Sun = 10/May → start = 4/May; no holidays
-  const r = inferCurrentPeriod(d('2026-05-14'));
   assert.equal(r.start, '2026-05-04');
   assert.equal(r.end, '2026-05-10');
   assert.equal(r.workdays, 5);
   assert.deepEqual(r.holidays, []);
 });
 
+test('inferCurrentPeriod: week with no holidays has 5 workdays', () => {
+  // Thu 14/May → this week's Sunday = 17/May → start = 11/May; no holidays
+  const r = inferCurrentPeriod(d('2026-05-14'));
+  assert.equal(r.start, '2026-05-11');
+  assert.equal(r.end, '2026-05-17');
+  assert.equal(r.workdays, 5);
+  assert.deepEqual(r.holidays, []);
+});
+
 test('inferCurrentPeriod: Good Friday 2026 (April 3) in sprint week', () => {
-  // Thu 9/Apr/2026 → last Sun = 5/Apr → start = 30/Mar; Good Friday Apr 3 is in range
-  const r = inferCurrentPeriod(d('2026-04-09'));
+  // Thu 2/Apr/2026 → this week's Sunday = 5/Apr → start = 30/Mar; Good Friday Apr 3 in range
+  const r = inferCurrentPeriod(d('2026-04-02'));
   assert.equal(r.start, '2026-03-30');
   assert.equal(r.end, '2026-04-05');
   assert.equal(r.workdays, 4);
@@ -83,8 +83,8 @@ test('inferCurrentPeriod: Good Friday 2026 (April 3) in sprint week', () => {
 });
 
 test('inferCurrentPeriod: week containing Tiradentes (Apr 21) has 4 workdays', () => {
-  // Mon 27/Apr → last Sun = 26/Apr → start = 20/Apr; Tiradentes 21/Apr in range → 4 workdays
-  const r = inferCurrentPeriod(d('2026-04-27'));
+  // Tue 21/Apr → this week's Sunday = 26/Apr → start = 20/Apr; Tiradentes 21/Apr in range
+  const r = inferCurrentPeriod(d('2026-04-21'));
   assert.equal(r.start, '2026-04-20');
   assert.equal(r.end, '2026-04-26');
   assert.equal(r.workdays, 4);

--- a/__tests__/trends.test.ts
+++ b/__tests__/trends.test.ts
@@ -161,3 +161,24 @@ test('loadSprintRecords: falls back to legacy sprint-final.md when no dated arch
   assert.equal(recs.length, 1);
   assert.deepEqual(recs[0].on_my_mind, ['L']);
 });
+
+test('loadSprintRecords: normalizes health-goal encoding (>= → ≥) (#70)', () => {
+  const r = makeRepo();
+  writeArchive(r, '2026-03-01', `---\nhealth_goals:\n  Sleep Score: "avg >= 80"\non_hold: []\n---\nbody\n`);
+  assert.equal(loadSprintRecords(r)[0].health_goals['Sleep Score'], 'avg ≥ 80');
+});
+
+test('computeTrends: project aliases merge spellings into one cadence row (#69)', () => {
+  const r = makeRepo();
+  fs.mkdirSync(path.join(r, '.sprints', 'projects'), { recursive: true });
+  fs.writeFileSync(
+    path.join(r, '.sprints', 'projects', 'SP Innovation Week.md'),
+    `---\ntype: project\naliases:\n  - SPIW talk\n  - São Paulo Innovation Week\n---\n`,
+  );
+  writeArchive(r, '2026-03-01', `---\nprojects:\n  - São Paulo Innovation Week\non_hold: []\n---\nbody\n`);
+  writeArchive(r, '2026-03-08', `---\nprojects:\n  - SPIW talk\non_hold: []\n---\nbody\n`);
+  const merged = computeTrends(r).projects.filter(p => p.name === 'SP Innovation Week');
+  assert.equal(merged.length, 1);
+  assert.equal(merged[0].sprints, 2);
+  assert.equal(merged[0].streak, 2);
+});

--- a/lib/archive.ts
+++ b/lib/archive.ts
@@ -124,6 +124,13 @@ export const fmNumber = (v?: FrontmatterValue): number | undefined => {
   return Number.isFinite(n) ? n : undefined;
 };
 
+/** Canonicalize a goal value (≥/≤ symbols, single spaces) for cross-sprint comparison (#70). */
+export const normalizeGoalValue = (s: string): string =>
+  s.replace(/>=/g, '≥').replace(/<=/g, '≤').replace(/\s+/g, ' ').trim();
+
+export const normalizeGoalMap = (m: Record<string, string>): Record<string, string> =>
+  Object.fromEntries(Object.entries(m).map(([k, v]) => [k, normalizeGoalValue(v)]));
+
 /**
  * Parse leading YAML frontmatter into a generic object. Supports the subset the
  * sprint docs use: scalars, block/inline lists of scalars, and one level of
@@ -206,5 +213,5 @@ export function loadLatestArchive(repoPath: string): ArchiveContext | null {
   // Frontmatter is authoritative when present; prose parsing is the fallback
   // for archives written before the frontmatter schema (#61).
   const planning = parseFrontmatter(content) ?? parsePriorPlanning(content);
-  return { path: filePath, date, ...planning };
+  return { path: filePath, date, ...planning, health_goals: normalizeGoalMap(planning.health_goals) };
 }

--- a/lib/period.ts
+++ b/lib/period.ts
@@ -43,11 +43,13 @@ function countWorkdays(start: Date, end: Date, holidays: Date[]): number {
 }
 
 export function inferCurrentPeriod(today: Date): Period {
-  // Sprints are fixed Mon–Sun calendar weeks. The closing sprint is the most
-  // recently completed Mon–Sun week (end = last Sunday ≤ today).
+  // Sprints are fixed Mon–Sun calendar weeks. The sprint under review is the
+  // week CONTAINING today (end = this week's Sunday, or today if it is Sunday),
+  // so the last-workday (Friday) /sprint-start reviews the week just worked
+  // rather than the previous, already-archived one (#68).
   const dow = today.getDay(); // 0=Sun … 6=Sat
-  const end = addDays(today, -dow); // rewind to Sunday (0 days if today is Sun)
-  const start = addDays(end, -6);   // Monday = Sunday − 6
+  const end = addDays(today, (7 - dow) % 7); // forward to this week's Sunday
+  const start = addDays(end, -6);            // Monday = Sunday − 6
   const holidays = holidaysBetween(start, end);
   return {
     start: toISO(start),

--- a/lib/trends.ts
+++ b/lib/trends.ts
@@ -8,6 +8,7 @@ import {
   fmArray,
   fmMap,
   fmNumber,
+  normalizeGoalMap,
 } from './archive.js';
 
 export interface SprintRecord {
@@ -47,6 +48,26 @@ function countFromEnd<T>(items: T[], pred: (x: T) => boolean): number {
   return n;
 }
 
+/**
+ * Map alternate project spellings → canonical name, from `.sprints/projects/*.md`
+ * notes: the filename is the canonical name and its `aliases:` frontmatter lists
+ * the variants. Without notes, names pass through unchanged. (#69)
+ */
+export function loadProjectAliases(repoPath: string): Map<string, string> {
+  const dir = path.join(repoPath, '.sprints', 'projects');
+  const aliases = new Map<string, string>();
+  if (!fs.existsSync(dir)) return aliases;
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
+    const canonical = entry.name.replace(/\.md$/, '');
+    aliases.set(canonical, canonical);
+    const obj = parseFrontmatterObject(fs.readFileSync(path.join(dir, entry.name), 'utf8'));
+    if (obj) for (const a of fmArray(obj.aliases)) aliases.set(a, canonical);
+  }
+  return aliases;
+}
+
 export function loadSprintRecords(repoPath: string): SprintRecord[] {
   let paths = archiveFiles(repoPath);
   if (paths.length === 0) {
@@ -69,11 +90,11 @@ export function loadSprintRecords(repoPath: string): SprintRecord[] {
         plan_workdays: fmNumber(obj.plan_workdays),
         projects: fmArray(obj.projects),
         improvement_goals: fmArray(obj.improvement_goals),
-        health_goals: fmMap(obj.health_goals),
+        health_goals: normalizeGoalMap(fmMap(obj.health_goals)),
         on_my_mind: fmArray(obj.on_my_mind),
         on_hold: fmArray(obj.on_hold),
         results_improvement: 'results_improvement' in obj ? fmMap(obj.results_improvement) : undefined,
-        results_health: 'results_health' in obj ? fmMap(obj.results_health) : undefined,
+        results_health: 'results_health' in obj ? normalizeGoalMap(fmMap(obj.results_health)) : undefined,
         results_planned: fmNumber(obj.results_planned),
         results_shipped: fmNumber(obj.results_shipped),
       });
@@ -86,7 +107,7 @@ export function loadSprintRecords(repoPath: string): SprintRecord[] {
         date,
         projects: [],
         improvement_goals: p.improvement_goals,
-        health_goals: p.health_goals,
+        health_goals: normalizeGoalMap(p.health_goals),
         on_my_mind: p.on_my_mind,
         on_hold: p.on_hold,
       });
@@ -103,16 +124,19 @@ function consecutiveAge(records: SprintRecord[], pick: (r: SprintRecord) => stri
   return latest.map(item => ({ item, age: countFromEnd(records, r => pick(r).includes(item)) }));
 }
 
-function projectCadence(records: SprintRecord[]): ProjectCadence[] {
+function projectCadence(records: SprintRecord[], aliases: Map<string, string>): ProjectCadence[] {
+  const canon = (name: string): string => aliases.get(name) ?? name;
+  const has = (r: SprintRecord, name: string): boolean => r.projects.some(p => canon(p) === name);
+
   const names = new Set<string>();
-  records.forEach(r => r.projects.forEach(p => names.add(p)));
+  records.forEach(r => r.projects.forEach(p => names.add(canon(p))));
 
   const out: ProjectCadence[] = [];
   for (const name of names) {
     let sprints = 0;
     let lastSeen = '';
-    for (const r of records) if (r.projects.includes(name)) { sprints++; lastSeen = r.date; }
-    out.push({ name, sprints, streak: countFromEnd(records, r => r.projects.includes(name)), lastSeen });
+    for (const r of records) if (has(r, name)) { sprints++; lastSeen = r.date; }
+    out.push({ name, sprints, streak: countFromEnd(records, r => has(r, name)), lastSeen });
   }
 
   return out.sort((a, b) => b.sprints - a.sprints || a.name.localeCompare(b.name));
@@ -126,6 +150,6 @@ export function computeTrends(repoPath: string): Trends {
       on_my_mind: consecutiveAge(sprints, r => r.on_my_mind),
       on_hold: consecutiveAge(sprints, r => r.on_hold),
     },
-    projects: projectCadence(sprints),
+    projects: projectCadence(sprints, loadProjectAliases(repoPath)),
   };
 }


### PR DESCRIPTION
Closes #68. Closes #69. Closes #70. (Findings from the `/sprint-start` test run.)

## #68 — period vs Friday cadence
`inferCurrentPeriod` now returns the Mon–Sun week **containing today** (end = this week's Sunday) instead of rewinding to the last completed Sunday. A Friday `/sprint-start` reviews the **in-progress week** (e.g. Jun 1–7), not the previous already-archived one — no more manual `--today` correction. `sprint-close` reads the period from the wip (not `inferCurrentPeriod`), so it's unaffected. `period.test.ts` + the CLI period test updated to the new model.

```
$ sprint.ts period --today 2026-06-05   # Friday
current: 2026-06-01 … 2026-06-07         # was 2026-05-25 … 05-31
```

## #69 — project-name aliases
`loadProjectAliases` reads `.sprints/projects/*.md` (filename = canonical name, `aliases:` frontmatter = variants); `projectCadence` maps each `projects[]` entry through it, so "São Paulo Innovation Week" / "SP Innovation Week" / "SPIW talk" collapse into one cadence row. No alias notes → behavior unchanged.

## #70 — goal-encoding normalization
`normalizeGoalValue` canonicalizes `>=`→`≥`, `<=`→`≤`, and collapses whitespace; applied to `health_goals` (and `results_health`) on read in `loadLatestArchive` and `trends`, so the same target reads identically across sprints.

## Tests
Updated period cases (incl. an explicit Friday `#68` case), alias-merge, and normalization tests in archive + trends. **157 tests green**, `check-skills` passes, and `period --today 2026-06-05` now returns Jun 1–7 directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)