### PR TITLE
fix: harden alias loader + scope goal normalization (review of #71)

### DIFF
--- a/__tests__/archive.test.ts
+++ b/__tests__/archive.test.ts
@@ -1,13 +1,17 @@
-import { test } from 'node:test';
+import { test, after } from 'node:test';
 import assert from 'node:assert/strict';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { latestArchivePath, parsePriorPlanning, parseFrontmatter, parseFrontmatterObject, loadLatestArchive } from '../lib/archive.js';
 
+const tmpDirs: string[] = [];
+after(() => { for (const d of tmpDirs) fs.rmSync(d, { recursive: true, force: true }); });
+
 function makeTmpRepo(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 're-plan-test-'));
   fs.mkdirSync(path.join(dir, '.sprints', 'archive'), { recursive: true });
+  tmpDirs.push(dir);
   return dir;
 }
 

--- a/__tests__/trends.test.ts
+++ b/__tests__/trends.test.ts
@@ -182,3 +182,30 @@ test('computeTrends: project aliases merge spellings into one cadence row (#69)'
   assert.equal(merged[0].sprints, 2);
   assert.equal(merged[0].streak, 2);
 });
+
+test('loadProjectAliases: accepts a scalar (non-list) alias value', () => {
+  const r = makeRepo();
+  fs.mkdirSync(path.join(r, '.sprints', 'projects'), { recursive: true });
+  fs.writeFileSync(path.join(r, '.sprints', 'projects', 'Foo.md'), `---\ntype: project\naliases: Bar\n---\n`);
+  writeArchive(r, '2026-03-01', `---\nprojects:\n  - Bar\non_hold: []\n---\nbody\n`);
+  const foo = computeTrends(r).projects.filter(p => p.name === 'Foo');
+  assert.equal(foo.length, 1);
+  assert.equal(foo[0].sprints, 1);
+});
+
+test('loadProjectAliases: an alias never shadows a real project note', () => {
+  const r = makeRepo();
+  fs.mkdirSync(path.join(r, '.sprints', 'projects'), { recursive: true });
+  fs.writeFileSync(path.join(r, '.sprints', 'projects', 'Beta.md'), `---\ntype: project\n---\n`);
+  fs.writeFileSync(path.join(r, '.sprints', 'projects', 'Zeta.md'), `---\ntype: project\naliases:\n  - Beta\n---\n`);
+  writeArchive(r, '2026-03-01', `---\nprojects:\n  - Beta\non_hold: []\n---\nbody\n`);
+  const beta = computeTrends(r).projects.find(p => p.name === 'Beta');
+  assert.ok(beta, 'Beta must remain its own project, not absorbed into Zeta');
+  assert.equal(beta.sprints, 1);
+});
+
+test('loadSprintRecords: normalization preserves internal spacing (#70 fix)', () => {
+  const r = makeRepo();
+  writeArchive(r, '2026-03-02', `---\nhealth_goals:\n  Sleep Score: "82  (rested)"\non_hold: []\n---\nbody\n`);
+  assert.equal(loadSprintRecords(r)[0].health_goals['Sleep Score'], '82  (rested)');
+});

--- a/__tests__/trends.test.ts
+++ b/__tests__/trends.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { loadSprintRecords, computeTrends } from '../lib/trends.js';
+import { loadSprintRecords, computeTrends, loadProjectAliases } from '../lib/trends.js';
 
 const tmpDirs: string[] = [];
 after(() => { for (const d of tmpDirs) fs.rmSync(d, { recursive: true, force: true }); });
@@ -199,9 +199,20 @@ test('loadProjectAliases: an alias never shadows a real project note', () => {
   fs.writeFileSync(path.join(r, '.sprints', 'projects', 'Beta.md'), `---\ntype: project\n---\n`);
   fs.writeFileSync(path.join(r, '.sprints', 'projects', 'Zeta.md'), `---\ntype: project\naliases:\n  - Beta\n---\n`);
   writeArchive(r, '2026-03-01', `---\nprojects:\n  - Beta\non_hold: []\n---\nbody\n`);
+  // "Beta" is a real project note, so a Zeta alias claiming it is ignored — the map
+  // has no "Beta" key, independent of filesystem read order (deterministic guard).
+  assert.equal(loadProjectAliases(r).get('Beta'), undefined);
   const beta = computeTrends(r).projects.find(p => p.name === 'Beta');
   assert.ok(beta, 'Beta must remain its own project, not absorbed into Zeta');
   assert.equal(beta.sprints, 1);
+});
+
+test('loadProjectAliases: same alias on two notes resolves deterministically (sorted first-wins)', () => {
+  const r = makeRepo();
+  fs.mkdirSync(path.join(r, '.sprints', 'projects'), { recursive: true });
+  fs.writeFileSync(path.join(r, '.sprints', 'projects', 'Alpha.md'), `---\ntype: project\naliases:\n  - Shared\n---\n`);
+  fs.writeFileSync(path.join(r, '.sprints', 'projects', 'Bravo.md'), `---\ntype: project\naliases:\n  - Shared\n---\n`);
+  assert.equal(loadProjectAliases(r).get('Shared'), 'Alpha'); // Alpha.md sorts first → wins
 });
 
 test('loadSprintRecords: normalization preserves internal spacing (#70 fix)', () => {

--- a/lib/archive.ts
+++ b/lib/archive.ts
@@ -124,7 +124,7 @@ export const fmNumber = (v?: FrontmatterValue): number | undefined => {
   return Number.isFinite(n) ? n : undefined;
 };
 
-/** Canonicalize goal-value operators (≥/≤) for cross-sprint comparison; preserves internal spacing (#70). */
+/** Canonicalize goal-value operators (>= → ≥, <= → ≤) and trim; preserves the user's internal spacing (#70). */
 export const normalizeGoalValue = (s: string): string =>
   s.replace(/>=/g, '≥').replace(/<=/g, '≤').trim();
 

--- a/lib/archive.ts
+++ b/lib/archive.ts
@@ -124,9 +124,9 @@ export const fmNumber = (v?: FrontmatterValue): number | undefined => {
   return Number.isFinite(n) ? n : undefined;
 };
 
-/** Canonicalize a goal value (≥/≤ symbols, single spaces) for cross-sprint comparison (#70). */
+/** Canonicalize goal-value operators (≥/≤) for cross-sprint comparison; preserves internal spacing (#70). */
 export const normalizeGoalValue = (s: string): string =>
-  s.replace(/>=/g, '≥').replace(/<=/g, '≤').replace(/\s+/g, ' ').trim();
+  s.replace(/>=/g, '≥').replace(/<=/g, '≤').trim();
 
 export const normalizeGoalMap = (m: Record<string, string>): Record<string, string> =>
   Object.fromEntries(Object.entries(m).map(([k, v]) => [k, normalizeGoalValue(v)]));

--- a/lib/trends.ts
+++ b/lib/trends.ts
@@ -55,15 +55,25 @@ function countFromEnd<T>(items: T[], pred: (x: T) => boolean): number {
  */
 export function loadProjectAliases(repoPath: string): Map<string, string> {
   const dir = path.join(repoPath, '.sprints', 'projects');
-  const aliases = new Map<string, string>();
+  const aliases = new Map<string, string>(); // variant → canonical (canonical names rely on canon()'s ?? fallback)
   if (!fs.existsSync(dir)) return aliases;
 
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
-    const canonical = entry.name.replace(/\.md$/, '');
-    aliases.set(canonical, canonical);
-    const obj = parseFrontmatterObject(fs.readFileSync(path.join(dir, entry.name), 'utf8'));
-    if (obj) for (const a of fmArray(obj.aliases)) aliases.set(a, canonical);
+  const files = fs.readdirSync(dir, { withFileTypes: true })
+    .filter(e => e.isFile() && e.name.endsWith('.md'))
+    .map(e => e.name)
+    .sort(); // deterministic resolution order, independent of filesystem order
+  const canonicals = new Set(files.map(f => f.replace(/\.md$/, '')));
+
+  for (const name of files) {
+    const canonical = name.replace(/\.md$/, '');
+    const raw = parseFrontmatterObject(fs.readFileSync(path.join(dir, name), 'utf8'))?.aliases;
+    // accept a YAML list OR a single scalar; ignore other shapes
+    const list = Array.isArray(raw) ? raw : typeof raw === 'string' && raw.trim() ? [raw] : [];
+    for (const alias of list) {
+      const a = alias.trim();
+      if (!a || canonicals.has(a)) continue;          // never let an alias shadow a real project note
+      if (!aliases.has(a)) aliases.set(a, canonical); // first (sorted) declaration wins — deterministic
+    }
   }
   return aliases;
 }
@@ -126,17 +136,18 @@ function consecutiveAge(records: SprintRecord[], pick: (r: SprintRecord) => stri
 
 function projectCadence(records: SprintRecord[], aliases: Map<string, string>): ProjectCadence[] {
   const canon = (name: string): string => aliases.get(name) ?? name;
-  const has = (r: SprintRecord, name: string): boolean => r.projects.some(p => canon(p) === name);
+  // canonicalize each sprint's projects once (parallel to `records`)
+  const canonSets = records.map(r => new Set(r.projects.map(canon)));
 
   const names = new Set<string>();
-  records.forEach(r => r.projects.forEach(p => names.add(canon(p))));
+  canonSets.forEach(s => s.forEach(n => names.add(n)));
 
   const out: ProjectCadence[] = [];
   for (const name of names) {
     let sprints = 0;
     let lastSeen = '';
-    for (const r of records) if (has(r, name)) { sprints++; lastSeen = r.date; }
-    out.push({ name, sprints, streak: countFromEnd(records, r => has(r, name)), lastSeen });
+    for (let i = 0; i < records.length; i++) if (canonSets[i].has(name)) { sprints++; lastSeen = records[i].date; }
+    out.push({ name, sprints, streak: countFromEnd(canonSets, s => s.has(name)), lastSeen });
   }
 
   return out.sort((a, b) => b.sprints - a.sprints || a.name.localeCompare(b.name));


### PR DESCRIPTION
Addresses the /code-review findings on #71 (no separate issues filed).

- **#1 scalar aliases:** `loadProjectAliases` now accepts a scalar *or* list `aliases:` (a scalar was silently dropped).
- **#2 collision determinism:** resolves in sorted, first-wins order (not filesystem order); an alias can never shadow a real project note; redundant canonical self-seed dropped.
- **#3 normalization over-reach:** `normalizeGoalValue` keeps only `>=`→`≥`/`<=`→`≤` + trim — no blanket whitespace-collapse, so intentional internal spacing and non-empty placeholders survive.
- **cleanup:** `projectCadence` precomputes a canonical Set per sprint; `archive.test.ts` gets an `after()` teardown.

Regression tests for each. **160 tests green.** Deferred (altitude/architectural, noted in review): moving the alias loader to archive.ts, sharing the dir-listing helper, and re-anchoring the period model off the archive series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)