### PR TITLE
fix(#73): strip "Plano do dia" section on sprint close

### DIFF
--- a/__tests__/document.test.ts
+++ b/__tests__/document.test.ts
@@ -1,0 +1,74 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { stripDayPlan } from '../lib/document.js';
+
+const FRONT = `---
+type: sprint
+---
+<!-- sprint-wip: 8/Jun–14/Jun | gerado em: 2026-06-05 -03 -->
+
+# 5/Jun -------------------------------------
+`;
+
+const DAY_PLAN = `
+## Plano do dia — 5/Jun (sexta-feira)
+
+Objetivo da semana: keep cadence.
+
+Status: Done — stuff. Pending — other stuff.
+
+Prioridades:
+1. Weekly Review
+2. Diar.ia
+
+Blocos de tempo sugeridos:
+16:00–17:00  Weekly Review
+`;
+
+const REVIEW = `
+## Sprint Review *(1/Jun–7/Jun, 5 workdays)*
+
+### Outcomes
+
+* Full recovery
+`;
+
+test('stripDayPlan: removes the day-plan section, keeping header + review', () => {
+  const out = stripDayPlan(FRONT + DAY_PLAN + REVIEW);
+  assert.doesNotMatch(out, /Plano do dia/);
+  assert.doesNotMatch(out, /Blocos de tempo/);
+  assert.match(out, /# 5\/Jun -+/);            // date header preserved
+  assert.match(out, /## Sprint Review/);        // review preserved
+  assert.match(out, /sprint-wip: 8\/Jun/);      // frontmatter/comment preserved
+  // date header is followed by exactly one blank line then Sprint Review
+  assert.match(out, /# 5\/Jun -+\n\n## Sprint Review/);
+});
+
+test('stripDayPlan: idempotent — no day plan returns content unchanged', () => {
+  const noPlan = FRONT + REVIEW;
+  assert.equal(stripDayPlan(noPlan), noPlan);
+  // running twice on a doc that had a plan yields the same result
+  const once = stripDayPlan(FRONT + DAY_PLAN + REVIEW);
+  assert.equal(stripDayPlan(once), once);
+});
+
+test('stripDayPlan: handles a day plan that runs to end of file', () => {
+  const out = stripDayPlan(FRONT + DAY_PLAN);
+  assert.doesNotMatch(out, /Plano do dia/);
+  assert.match(out, /# 5\/Jun -+/);
+  assert.ok(out.endsWith('\n'));
+});
+
+test('stripDayPlan: tolerates CRLF input and normalizes the seam to LF', () => {
+  const crlf = (FRONT + DAY_PLAN + REVIEW).replace(/\n/g, '\r\n');
+  const out = stripDayPlan(crlf);
+  assert.doesNotMatch(out, /Plano do dia/);
+  assert.match(out, /# 5\/Jun -+\n\n## Sprint Review/); // seam has no stray \r
+});
+
+test('stripDayPlan: matches heading case-insensitively', () => {
+  const upper = FRONT + '\n## PLANO DO DIA — x\n\ntext\n' + REVIEW;
+  const out = stripDayPlan(upper);
+  assert.doesNotMatch(out, /PLANO DO DIA/i);
+  assert.match(out, /## Sprint Review/);
+});

--- a/__tests__/wip.test.ts
+++ b/__tests__/wip.test.ts
@@ -92,3 +92,26 @@ test('archiveWip: throws when sprint-wip.md does not exist', () => {
   const repo = makeTmpRepo();
   assert.throws(() => archiveWip(repo, '2026-05-03'), /sprint-wip\.md not found/);
 });
+
+test('archiveWip: strips the "Plano do dia" section from archive and wip (#73)', () => {
+  const repo = makeTmpRepo();
+  const wip = `# 5/Jun -------------------------------------
+
+## Plano do dia — 5/Jun (sexta-feira)
+
+Foco: close the week.
+
+## Sprint Review *(27/Abr–3/Mai, 5 workdays)*
+
+### Outcomes
+`;
+  const src = path.join(repo, '.sprints', 'sprint-wip.md');
+  fs.writeFileSync(src, wip);
+  const dest = archiveWip(repo, '2026-05-03');
+
+  for (const file of [dest, src]) {
+    const body = fs.readFileSync(file, 'utf8');
+    assert.doesNotMatch(body, /Plano do dia/, `${file} should not contain the day plan`);
+    assert.match(body, /# 5\/Jun -+\n\n## Sprint Review/, `${file} should join header to review`);
+  }
+});

--- a/lib/document.ts
+++ b/lib/document.ts
@@ -1,0 +1,41 @@
+/**
+ * Remove the "## Plano do dia" section from a sprint document.
+ *
+ * `/sprint-start` writes a day-plan block (day goal, status, focus, suggested
+ * time blocks) at the top of `sprint-wip.md`. That block is a morning snapshot
+ * and does not belong in the closed sprint document, which should hold only
+ * Sprint Review / Retrospective / Planning — matching the archived format
+ * (`.sprints/archive/<date>.md`), where `# <date>` is followed directly by
+ * `## Sprint Review`.
+ *
+ * Strips from the `## Plano do dia …` heading up to — but not including — the
+ * next `## ` heading (normally `## Sprint Review`), collapsing the blank lines
+ * left behind so the date header is followed by a single blank line. Returns
+ * the content unchanged when there is no day-plan section, so it is safe to run
+ * more than once (idempotent). Match is case-insensitive to tolerate heading
+ * casing drift.
+ */
+export function stripDayPlan(content: string): string {
+  // Split on \r?\n so the scan is line-ending-agnostic (CRLF checkouts on
+  // Windows): a trailing \r would otherwise leak into the rejoined output.
+  const lines = content.split(/\r?\n/);
+  const start = lines.findIndex(l => /^##\s+plano do dia\b/i.test(l));
+  if (start === -1) return content;
+
+  // First H2 at or after the day-plan heading marks the end of the section.
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^##\s/.test(lines[i])) { end = i; break; }
+  }
+
+  const before = lines.slice(0, start);
+  const after = lines.slice(end);
+  // Drop trailing blanks left above the removed section (e.g. after `# <date>`).
+  while (before.length && before[before.length - 1].trim() === '') before.pop();
+
+  // Day-plan ran to EOF (no following section): just drop it.
+  if (after.length === 0) return before.join('\n') + '\n';
+
+  // Re-join the date header to the next section with a single blank line.
+  return [...before, '', ...after].join('\n');
+}

--- a/lib/wip.ts
+++ b/lib/wip.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { stripDayPlan } from './document.js';
 
 export interface WipData {
   path: string;
@@ -28,9 +29,14 @@ export function archiveWip(repoPath: string, endDate: string): string {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(endDate)) throw new Error(`Invalid date: ${endDate}`);
   const src = wipPath(repoPath);
   if (!fs.existsSync(src)) throw new Error('sprint-wip.md not found');
+  // Finalize the wip on archive: drop the `## Plano do dia` morning snapshot so
+  // both the archive and the file uploaded to the Google Doc carry only
+  // Review/Retro/Planning. Idempotent — a no-op once the section is gone. (#73)
+  const cleaned = stripDayPlan(fs.readFileSync(src, 'utf8'));
+  fs.writeFileSync(src, cleaned);
   const archiveDir = path.join(repoPath, '.sprints', 'archive');
   fs.mkdirSync(archiveDir, { recursive: true });
   const dest = path.join(archiveDir, `${endDate}.md`);
-  fs.copyFileSync(src, dest);
+  fs.writeFileSync(dest, cleaned);
   return dest;
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "check-sync": "node build.js --check",
     "install-skills": "bash bin/install-skills.sh",
     "check-skills": "bash bin/check-skills.sh",
-    "test": "node --test __tests__/parser.test.js __tests__/insert.test.js __tests__/skill-checks.test.js && node -r tsx/cjs --test __tests__/period.test.ts __tests__/archive.test.ts __tests__/trends.test.ts __tests__/wip.test.ts __tests__/filters.test.ts __tests__/cli.test.ts"
+    "test": "node --test __tests__/parser.test.js __tests__/insert.test.js __tests__/skill-checks.test.js && node -r tsx/cjs --test __tests__/period.test.ts __tests__/archive.test.ts __tests__/trends.test.ts __tests__/wip.test.ts __tests__/document.test.ts __tests__/filters.test.ts __tests__/cli.test.ts"
   },
   "engines": {
     "node": ">=18"

--- a/sprint-close.md
+++ b/sprint-close.md
@@ -64,6 +64,7 @@ Coletei os dados que faltaram. Agora preciso dos resultados anotados no papel pa
 
 Mescle o rascunho com os novos dados:
 - Substitua todos os `[PENDING]` pelos valores reais
+- **Remova a seção `## Plano do dia`** (snapshot da manhã, herdado do `/sprint-start`) — o documento fechado deve conter só Review / Retro / Planning. O `archive-wip` (PASSO 6) também remove essa seção automaticamente, então isso é uma rede de segurança (#73)
 - Adicione os novos Outputs/Outcomes do fim de semana
 - Complete as seções narrativas (What could be improved, What will I commit) se ainda pendentes — em **estilo scrum** (bullets curtos e acionáveis; o "commit" é um action item concreto e rastreável, conforme `/sprint-start` PASSO 4b)
 - Ajuste o Sprint Planning se necessário
@@ -105,7 +106,7 @@ Após a versão final estar aprovada:
 node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts archive-wip --repo <<REPO_PATH>> --date YYYY-MM-DD
 ```
 
-O comando cria `.sprints/archive/<DATA>.md` (sobrescreve em reruns do mesmo ciclo — intencional).
+O comando cria `.sprints/archive/<DATA>.md` (sobrescreve em reruns do mesmo ciclo — intencional). Ele também **remove a seção `## Plano do dia`** do `sprint-wip.md` e da cópia arquivada (operação idempotente), garantindo que tanto o arquivo quanto o que sobe pro Google Doc fiquem só com Review / Retro / Planning (#73).
 
 O arquivo arquivado é a **fonte de contexto** que `/sprint-start` (PASSO 1b) lê na próxima sexta para preservar "On my mind", "On hold" e metas de Health entre sprints. Não apague — sobrescrever o `sprint-wip.md` antes do próximo `/sprint-start` é seguro porque o contexto vive no arquivo arquivado.
 


### PR DESCRIPTION
Closes #73.

## What

`/sprint-close`'s final document was inheriting the `## Plano do dia` morning snapshot from `sprint-wip.md` (written by `/sprint-start`). That block doesn't belong in the closed sprint doc — the archived format goes `# <date>` → `## Sprint Review` directly — and its stale "Status" line drifts from the Review once gap-day data is merged in.

## How

- New pure helper `lib/document.ts` → `stripDayPlan(content)`: removes the `## Plano do dia …` section up to the next `## ` heading, collapsing the blank lines so the date header is followed by a single blank line. Idempotent (no-op when absent), case-insensitive, CRLF-tolerant.
- `archiveWip` (the `archive-wip` step always run in PASSO 6) now strips the section from **both** the rewritten `sprint-wip.md` and the archived copy. This makes the removal **deterministic** — it no longer depends on the model remembering to omit it — and the file uploaded to the Google Doc is clean too.
- `sprint-close.md` PASSO 4/6 updated to document the behavior (placeholder-safe, `check-skills.sh` stays green).

## Tests

- `__tests__/document.test.ts` — strip / idempotency / EOF / CRLF / case-insensitivity (5 cases)
- `__tests__/wip.test.ts` — `archiveWip` strips from archive **and** wip
- Full suite: 106 passing.

## Review

Ran `/code-review` (xhigh). One finding (CRLF line-ending fragility in the split) — fixed and covered by a regression test before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)