### PR TITLE
feat(#74): configurable sprint data dir (SPRINT_DATA_DIR) for OneDrive sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,6 @@
 APPS_SCRIPT_ID=your-script-id-here
+
+# Optional: relocate the sprint data (sprint-wip.md, archive/, projects/, the
+# Obsidian vault) out of <repo>/.sprints — e.g. into a OneDrive-synced folder so
+# it is backed up and shared across machines. Use forward slashes. (#74)
+# SPRINT_DATA_DIR=C:/Users/you/OneDrive/Documents/Re-plan/data

--- a/SETUP.md
+++ b/SETUP.md
@@ -65,6 +65,22 @@ Edit `.env`:
 APPS_SCRIPT_ID=your-script-id-here
 ```
 
+#### Optional: relocate the sprint data (`SPRINT_DATA_DIR`)
+
+By default the sprint data — `sprint-wip.md`, `archive/`, `projects/`, and the
+Obsidian vault — lives in `<repo>/.sprints` (gitignored, so it is **not** backed
+up by Git). To keep it backed up and synced across machines, point it at a
+cloud-synced folder (e.g. OneDrive) by adding to `.env`:
+
+```
+SPRINT_DATA_DIR=C:/Users/you/OneDrive/Documents/Re-plan/data
+```
+
+Then move the existing `.sprints` contents into that folder. Both the CLI
+(`bin/sprint.ts`, which loads `<repo>/.env`) and `upload-sprint.js` honor it; a
+real environment variable or a `--data <path>` CLI flag take precedence. Use
+forward slashes to avoid backslash-escaping surprises in `.env`. (#74)
+
 > **Migrating from `APPS_SCRIPT_DEPLOY_ID`:** if your existing `.env` uses the older variable name, just rename the key to `APPS_SCRIPT_ID`. The value (Script ID) is the same — earlier docs misnamed it as "Deployment ID", but `script.scripts.run` and `script.projects.get` always required the Script ID. See issue #5.
 
 ### Step 6: Install skill files
@@ -115,7 +131,7 @@ On first run, a browser window will open for Google authentication.
 |------|---------|
 | `upload-sprint.js` | Node.js script — reads file and calls Apps Script |
 | `insert-sprint.gs` | Google Apps Script — formats and inserts into Google Doc |
-| `.env` | Local config (`APPS_SCRIPT_ID`) — not committed |
+| `.env` | Local config (`APPS_SCRIPT_ID`, optional `SPRINT_DATA_DIR`) — not committed |
 | `.env.example` | Template for `.env` |
 | `credentials.json` | OAuth 2.0 credentials (create via Google Cloud Console) — not committed |
 | `token.json` | Auto-generated after first auth — not committed |

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -14,11 +14,17 @@ const TSX_CJS = createRequire(path.join(REPO_ROOT, 'package.json')).resolve('tsx
 interface RunResult { status: number | null; stdout: string; stderr: string }
 
 function run(args: string[], opts: { input?: string; cwd?: string } = {}): RunResult {
+  // Strip SPRINT_DATA_DIR from the child env so default-path tests are
+  // deterministic even when the dev has it exported in their shell/OS (#74).
+  // The --data test sets it explicitly via the flag inside the child instead.
+  const env = { ...process.env };
+  delete env.SPRINT_DATA_DIR;
   const spawnOpts: SpawnSyncOptionsWithStringEncoding = {
     encoding: 'utf8',
     cwd: opts.cwd ?? REPO_ROOT,
     input: opts.input,
     timeout: 10_000,
+    env,
   };
   const r = spawnSync('node', ['-r', TSX_CJS, SPRINT_BIN, ...args], spawnOpts);
   return { status: r.status, stdout: r.stdout, stderr: r.stderr };
@@ -135,6 +141,30 @@ test('cli: archive-wip rejects bad date format', () => {
   const r = run(['archive-wip', '--repo', repo, '--date', '3-Mai']);
   assert.equal(r.status, 1);
   assert.match(r.stderr, /YYYY-MM-DD/);
+});
+
+test('cli: --data relocates the sprint data dir away from <repo>/.sprints (#74)', () => {
+  const repo = tmpRepo(); // has an empty <repo>/.sprints, no wip
+  const data = fs.mkdtempSync(path.join(os.tmpdir(), 're-plan-cli-data-'));
+  fs.writeFileSync(
+    path.join(data, 'sprint-wip.md'),
+    '<!-- sprint-wip: 8/Jun–14/Jun | gerado em: 2026-06-05 -->\nbody\n'
+  );
+
+  // Without --data the wip is not found (repo/.sprints is empty)...
+  const without = run(['read-wip', '--repo', repo]);
+  assert.equal(without.status, 1, 'expected not-found without --data');
+
+  // ...with --data pointing at the relocated dir, it is.
+  const withData = run(['read-wip', '--repo', repo, '--data', data]);
+  assert.equal(withData.status, 0, withData.stderr);
+  assert.equal(JSON.parse(withData.stdout).period, '8/Jun–14/Jun');
+
+  // archive-wip also writes into the relocated dir, not <repo>/.sprints.
+  const arch = run(['archive-wip', '--repo', repo, '--data', data, '--date', '2026-06-07']);
+  assert.equal(arch.status, 0, arch.stderr);
+  assert.ok(fs.existsSync(path.join(data, 'archive', '2026-06-07.md')));
+  assert.ok(!fs.existsSync(path.join(repo, '.sprints', 'archive', '2026-06-07.md')));
 });
 
 // ──────────────────────────── filters via stdin ─────────────────

--- a/__tests__/paths.test.ts
+++ b/__tests__/paths.test.ts
@@ -1,0 +1,31 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import * as path from 'node:path';
+import { sprintsDir } from '../lib/paths.js';
+
+const PREV = process.env.SPRINT_DATA_DIR;
+function restore(): void {
+  if (PREV === undefined) delete process.env.SPRINT_DATA_DIR;
+  else process.env.SPRINT_DATA_DIR = PREV;
+}
+
+test('sprintsDir: defaults to <repo>/.sprints when env is unset', () => {
+  delete process.env.SPRINT_DATA_DIR;
+  try {
+    assert.equal(sprintsDir(path.join('/tmp', 'repo')), path.join('/tmp', 'repo', '.sprints'));
+  } finally { restore(); }
+});
+
+test('sprintsDir: SPRINT_DATA_DIR overrides the default', () => {
+  process.env.SPRINT_DATA_DIR = path.join('/data', 'sprints');
+  try {
+    assert.equal(sprintsDir(path.join('/tmp', 'repo')), path.join('/data', 'sprints'));
+  } finally { restore(); }
+});
+
+test('sprintsDir: blank/whitespace env is treated as unset', () => {
+  process.env.SPRINT_DATA_DIR = '   ';
+  try {
+    assert.equal(sprintsDir(path.join('/tmp', 'repo')), path.join('/tmp', 'repo', '.sprints'));
+  } finally { restore(); }
+});

--- a/bin/sprint.ts
+++ b/bin/sprint.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import * as path from 'node:path';
+import * as dotenv from 'dotenv';
 import { inferCurrentPeriod, nextPeriod } from '../lib/period.js';
 import { loadLatestArchive } from '../lib/archive.js';
 import { computeTrends } from '../lib/trends.js';
@@ -61,6 +63,14 @@ function requireISODate(name: string, value: string | undefined): string {
 }
 
 async function main(): Promise<void> {
+  // Load <repo>/.env so SPRINT_DATA_DIR (data-dir relocation, e.g. a
+  // OneDrive-synced folder) applies to the CLI just like it does to
+  // upload-sprint.js. dotenv never overrides a real env var; an explicit
+  // --data flag wins over both. (#74)
+  dotenv.config({ path: path.join(repoPath(), '.env') });
+  const dataFlag = flag(args, '--data');
+  if (dataFlag) process.env.SPRINT_DATA_DIR = dataFlag;
+
   switch (subcommand) {
     case 'period': {
       const todayStr = flag(args, '--today');

--- a/lib/archive.ts
+++ b/lib/archive.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { sprintsDir } from './paths.js';
 
 export interface ArchiveContext {
   path: string;
@@ -14,7 +15,7 @@ const ARCHIVE_FILE_RE = /^\d{4}-\d{2}-\d{2}\.md$/;
 
 /** Dated archive files (full paths) sorted ascending by date. Excludes directories. */
 export function archiveFiles(repoPath: string): string[] {
-  const dir = path.join(repoPath, '.sprints', 'archive');
+  const dir = path.join(sprintsDir(repoPath), 'archive');
   if (!fs.existsSync(dir)) return [];
   return fs.readdirSync(dir, { withFileTypes: true })
     .filter(d => d.isFile() && ARCHIVE_FILE_RE.test(d.name))
@@ -24,7 +25,7 @@ export function archiveFiles(repoPath: string): string[] {
 }
 
 export function legacyArchivePath(repoPath: string): string {
-  return path.join(repoPath, '.sprints', 'sprint-final.md');
+  return path.join(sprintsDir(repoPath), 'sprint-final.md');
 }
 
 export function latestArchivePath(repoPath: string): string | null {

--- a/lib/paths.ts
+++ b/lib/paths.ts
@@ -1,0 +1,17 @@
+import * as path from 'node:path';
+
+/**
+ * Directory holding the sprint data — `sprint-wip.md`, `archive/`, `projects/`,
+ * and the Obsidian vault.
+ *
+ * Defaults to `<repo>/.sprints` (the historical layout), but can be relocated
+ * via the `SPRINT_DATA_DIR` env var — e.g. into a OneDrive-synced folder so the
+ * data is backed up and shared across machines while the code stays in the Git
+ * repo. An empty/whitespace value is treated as unset. `bin/sprint.ts` loads
+ * `<repo>/.env` so the variable can be set there once for both the CLI and
+ * `upload-sprint.js`. (#74)
+ */
+export function sprintsDir(repoPath: string): string {
+  const override = process.env.SPRINT_DATA_DIR;
+  return override && override.trim() ? override : path.join(repoPath, '.sprints');
+}

--- a/lib/trends.ts
+++ b/lib/trends.ts
@@ -10,6 +10,7 @@ import {
   fmNumber,
   normalizeGoalMap,
 } from './archive.js';
+import { sprintsDir } from './paths.js';
 
 export interface SprintRecord {
   date: string;
@@ -54,7 +55,7 @@ function countFromEnd<T>(items: T[], pred: (x: T) => boolean): number {
  * the variants. Without notes, names pass through unchanged. (#69)
  */
 export function loadProjectAliases(repoPath: string): Map<string, string> {
-  const dir = path.join(repoPath, '.sprints', 'projects');
+  const dir = path.join(sprintsDir(repoPath), 'projects');
   const aliases = new Map<string, string>(); // variant → canonical (canonical names rely on canon()'s ?? fallback)
   if (!fs.existsSync(dir)) return aliases;
 

--- a/lib/wip.ts
+++ b/lib/wip.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { stripDayPlan } from './document.js';
+import { sprintsDir } from './paths.js';
 
 export interface WipData {
   path: string;
@@ -10,7 +11,7 @@ export interface WipData {
 }
 
 function wipPath(repoPath: string): string {
-  return path.join(repoPath, '.sprints', 'sprint-wip.md');
+  return path.join(sprintsDir(repoPath), 'sprint-wip.md');
 }
 
 function parseWipHeader(content: string): { period: string; generated_at: string } {
@@ -34,7 +35,7 @@ export function archiveWip(repoPath: string, endDate: string): string {
   // Review/Retro/Planning. Idempotent — a no-op once the section is gone. (#73)
   const cleaned = stripDayPlan(fs.readFileSync(src, 'utf8'));
   fs.writeFileSync(src, cleaned);
-  const archiveDir = path.join(repoPath, '.sprints', 'archive');
+  const archiveDir = path.join(sprintsDir(repoPath), 'archive');
   fs.mkdirSync(archiveDir, { recursive: true });
   const dest = path.join(archiveDir, `${endDate}.md`);
   fs.writeFileSync(dest, cleaned);

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "check-sync": "node build.js --check",
     "install-skills": "bash bin/install-skills.sh",
     "check-skills": "bash bin/check-skills.sh",
-    "test": "node --test __tests__/parser.test.js __tests__/insert.test.js __tests__/skill-checks.test.js && node -r tsx/cjs --test __tests__/period.test.ts __tests__/archive.test.ts __tests__/trends.test.ts __tests__/wip.test.ts __tests__/document.test.ts __tests__/filters.test.ts __tests__/cli.test.ts"
+    "test": "node --test __tests__/parser.test.js __tests__/insert.test.js __tests__/skill-checks.test.js && node -r tsx/cjs --test __tests__/period.test.ts __tests__/archive.test.ts __tests__/trends.test.ts __tests__/wip.test.ts __tests__/document.test.ts __tests__/paths.test.ts __tests__/filters.test.ts __tests__/cli.test.ts"
   },
   "engines": {
     "node": ">=18"

--- a/upload-sprint.js
+++ b/upload-sprint.js
@@ -1,6 +1,8 @@
-require('dotenv').config();
 const fs = require('fs');
 const path = require('path');
+// Load .env from the script's own dir (not cwd) so config is found regardless
+// of where the upload is invoked from.
+require('dotenv').config({ path: path.join(__dirname, '.env') });
 const { google } = require('googleapis');
 const { authenticate } = require('@google-cloud/local-auth');
 
@@ -12,7 +14,12 @@ const SCOPES = [
 
 const CREDENTIALS_PATH = path.join(__dirname, 'credentials.json');
 const TOKEN_PATH = path.join(__dirname, 'token.json');
-const SPRINT_FILE_PATH = path.join(__dirname, '.sprints', 'sprint-wip.md');
+// Mirror lib/paths.ts sprintsDir(): SPRINT_DATA_DIR relocates the sprint data
+// (e.g. a OneDrive-synced folder); default to the in-repo .sprints. (#74)
+const DATA_DIR = process.env.SPRINT_DATA_DIR && process.env.SPRINT_DATA_DIR.trim()
+  ? process.env.SPRINT_DATA_DIR
+  : path.join(__dirname, '.sprints');
+const SPRINT_FILE_PATH = path.join(DATA_DIR, 'sprint-wip.md');
 const SCRIPT_ID = process.env.APPS_SCRIPT_ID;
 
 async function loadSavedCredentials() {


### PR DESCRIPTION
Closes #74.

## Why

`.sprints/` (sprint-wip.md, archive/, projects/, the Obsidian vault) lived inside the repo and is **gitignored** — so it was neither versioned nor synced across machines. This decouples the **data** (relocatable to a OneDrive-synced folder) from the **code** (stays in the Git repo).

## How

- **`lib/paths.ts` → `sprintsDir(repoPath)`**: returns `SPRINT_DATA_DIR` when set, else `<repo>/.sprints` (blank/whitespace treated as unset). Single source of truth.
- `lib/wip.ts`, `lib/archive.ts`, `lib/trends.ts` now resolve their paths through `sprintsDir()` — signatures unchanged, so all callers and existing tests are unaffected when the var is unset.
- **`bin/sprint.ts`** loads `<repo>/.env` (so the var can be set there once for both entry points) and accepts a `--data <path>` flag. Precedence: `--data` flag > real env var > `.env` > default.
- **`upload-sprint.js`** mirrors the same resolution (CJS can't import the TS helper) and now loads `.env` from `__dirname` rather than cwd.
- Docs: `SETUP.md` + `.env.example`.

## Tests

- `__tests__/paths.test.ts` — default / override / blank-env (3 cases)
- `__tests__/cli.test.ts` — `--data` relocates read-wip + archive-wip end-to-end; `run()` now strips `SPRINT_DATA_DIR` from the child env for determinism
- Full suite: 110 passing.

## Review

Ran `/code-review` (xhigh). One finding — `run()` inheriting an ambient `SPRINT_DATA_DIR` could break the default-path CLI tests on a machine that exports it — fixed before this PR.

## Activation (local, not in this PR)

The physical move of `.sprints/` → `OneDrive/Documentos/Re-plan/data` and the `.env` `SPRINT_DATA_DIR` line are machine-local (both gitignored). Done separately after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)