### PR TITLE
docs(#78): use Re-plan-data convention in SPRINT_DATA_DIR examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,4 @@ APPS_SCRIPT_ID=your-script-id-here
 # Optional: relocate the sprint data (sprint-wip.md, archive/, projects/, the
 # Obsidian vault) out of <repo>/.sprints — e.g. into a OneDrive-synced folder so
 # it is backed up and shared across machines. Use forward slashes. (#74)
-# SPRINT_DATA_DIR=C:/Users/you/OneDrive/Documents/Re-plan/data
+# SPRINT_DATA_DIR=C:/Users/you/OneDrive/Documents/Re-plan-data

--- a/SETUP.md
+++ b/SETUP.md
@@ -73,7 +73,7 @@ up by Git). To keep it backed up and synced across machines, point it at a
 cloud-synced folder (e.g. OneDrive) by adding to `.env`:
 
 ```
-SPRINT_DATA_DIR=C:/Users/you/OneDrive/Documents/Re-plan/data
+SPRINT_DATA_DIR=C:/Users/you/OneDrive/Documents/Re-plan-data
 ```
 
 Then move the existing `.sprints` contents into that folder. Both the CLI


### PR DESCRIPTION
Updates the `SPRINT_DATA_DIR` example paths in SETUP.md and .env.example to the flatter `Re-plan-data` convention adopted in #78 (avoids the nested `data/` and the name collision with the code repo). Doc-only; ran /code-review (no findings).