### PR TITLE
feat: add day-plan and day-wrap skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ The process runs in two stages:
 
 > **Data location.** The sprint data (`sprint-wip.md`, `archive/`, the Obsidian vault) defaults to `.sprints/` inside the repo, which is gitignored. Set `SPRINT_DATA_DIR` in `.env` to relocate it — e.g. a OneDrive-synced folder for backup and sync across machines. See [SETUP.md](SETUP.md) (`SPRINT_DATA_DIR`). (#74)
 
+### Daily companions
+
+Two optional daily commands sit alongside the weekly cadence above — neither writes to the sprint document, both read from it:
+
+**`/day-plan`** — Run each morning
+- Clears the TickTick Inbox, lists today's tasks, surfaces overdue ones for triage
+- Pulls today's calendar and suggests time blocks around existing meetings
+- Proposes a single main focus for the day, connected to the active sprint's Projects Priority
+
+**`/day-wrap`** — Run each evening
+- Reviews today's completed tasks, and checks in separately on today's Improvement and Health goals
+- Triages anything left undone, and helps plan tomorrow's tasks and calendar
+- Appends a one-line entry to `day-log.md` (same data directory as `sprint-wip.md`) — a running log meant to make the next `/sprint-start` reconstruction lighter
+
 ## Required MCPs
 
 | Tool | MCP |

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -143,6 +143,30 @@ test('cli: archive-wip rejects bad date format', () => {
   assert.match(r.stderr, /YYYY-MM-DD/);
 });
 
+test('cli: append-day-log writes a dated line to day-log.md', () => {
+  const repo = tmpRepo();
+  const r = run(['append-day-log', '--repo', repo, '--date', '2026-06-30'], {
+    input: 'output: shipped X | blocker: none'
+  });
+  assert.equal(r.status, 0, r.stderr);
+  const dest = path.join(repo, '.sprints', 'day-log.md');
+  assert.equal(fs.readFileSync(dest, 'utf8'), '- [2026-06-30]: output: shipped X | blocker: none\n');
+});
+
+test('cli: append-day-log rejects bad date format', () => {
+  const repo = tmpRepo();
+  const r = run(['append-day-log', '--repo', repo, '--date', '30/Jun'], { input: 'x' });
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /YYYY-MM-DD/);
+});
+
+test('cli: append-day-log rejects empty stdin', () => {
+  const repo = tmpRepo();
+  const r = run(['append-day-log', '--repo', repo, '--date', '2026-06-30'], { input: '   ' });
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /non-empty line/);
+});
+
 test('cli: --data relocates the sprint data dir away from <repo>/.sprints (#74)', () => {
   const repo = tmpRepo(); // has an empty <repo>/.sprints, no wip
   const data = fs.mkdtempSync(path.join(os.tmpdir(), 're-plan-cli-data-'));

--- a/__tests__/daylog.test.ts
+++ b/__tests__/daylog.test.ts
@@ -1,0 +1,57 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { appendDayLog } from '../lib/daylog.js';
+
+function makeTmpRepo(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 're-plan-daylog-test-'));
+  fs.mkdirSync(path.join(dir, '.sprints'), { recursive: true });
+  return dir;
+}
+
+test('appendDayLog: creates day-log.md with a dated line', () => {
+  const repo = makeTmpRepo();
+  const dest = appendDayLog(repo, '2026-06-30', 'output: shipped X | blocker: none');
+  assert.ok(fs.existsSync(dest));
+  assert.equal(
+    fs.readFileSync(dest, 'utf8'),
+    '- [2026-06-30]: output: shipped X | blocker: none\n'
+  );
+  assert.ok(dest.endsWith('day-log.md'));
+});
+
+test('appendDayLog: appends, never overwrites', () => {
+  const repo = makeTmpRepo();
+  appendDayLog(repo, '2026-06-30', 'first entry');
+  const dest = appendDayLog(repo, '2026-07-01', 'second entry');
+  const body = fs.readFileSync(dest, 'utf8');
+  assert.equal(body, '- [2026-06-30]: first entry\n- [2026-07-01]: second entry\n');
+});
+
+test('appendDayLog: trims surrounding whitespace from the line', () => {
+  const repo = makeTmpRepo();
+  const dest = appendDayLog(repo, '2026-06-30', '  output: x  \n');
+  assert.equal(fs.readFileSync(dest, 'utf8'), '- [2026-06-30]: output: x\n');
+});
+
+test('appendDayLog: creates the data dir if it does not exist', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 're-plan-daylog-nodir-'));
+  const dest = appendDayLog(dir, '2026-06-30', 'entry');
+  assert.ok(fs.existsSync(dest));
+});
+
+test('appendDayLog: throws on invalid date format', () => {
+  const repo = makeTmpRepo();
+  assert.throws(() => appendDayLog(repo, '30/Jun', 'entry'), /Invalid date/);
+});
+
+test('appendDayLog: does not shell-expand $ or backticks in the line (#7 review finding)', () => {
+  const repo = makeTmpRepo();
+  const dest = appendDayLog(repo, '2026-06-30', 'output: saved $50 via `discount`');
+  assert.equal(
+    fs.readFileSync(dest, 'utf8'),
+    '- [2026-06-30]: output: saved $50 via `discount`\n'
+  );
+});

--- a/__tests__/skill-checks.test.js
+++ b/__tests__/skill-checks.test.js
@@ -20,6 +20,8 @@ function writeFixture(content) {
   fs.writeFileSync(path.join(dir, 'sprint-start.md'), content);
   fs.writeFileSync(path.join(dir, 'sprint-update.md'), '');
   fs.writeFileSync(path.join(dir, 'sprint-close.md'), '');
+  fs.writeFileSync(path.join(dir, 'day-plan.md'), '');
+  fs.writeFileSync(path.join(dir, 'day-wrap.md'), '');
   return dir;
 }
 

--- a/bin/check-skills.sh
+++ b/bin/check-skills.sh
@@ -16,7 +16,7 @@ set -euo pipefail
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SRC_DIR="${1:-$REPO_DIR}"
 
-skills=( "$SRC_DIR/sprint-start.md" "$SRC_DIR/sprint-update.md" "$SRC_DIR/sprint-close.md" )
+skills=( "$SRC_DIR/sprint-start.md" "$SRC_DIR/sprint-update.md" "$SRC_DIR/sprint-close.md" "$SRC_DIR/day-plan.md" "$SRC_DIR/day-wrap.md" )
 
 # ----------------------------------------------------------------------------
 # Check 1: skill files must not embed clone-specific user-home paths.

--- a/bin/install-skills.sh
+++ b/bin/install-skills.sh
@@ -33,7 +33,7 @@ if [ ! -f "$REPO_DIR/node_modules/.bin/tsx" ] && [ ! -f "$REPO_DIR/node_modules/
   echo "warning: tsx not found in node_modules. Run 'npm install' before using the skills." >&2
 fi
 
-for f in sprint-start.md sprint-update.md sprint-close.md; do
+for f in sprint-start.md sprint-update.md sprint-close.md day-plan.md day-wrap.md; do
   src="${REPO_DIR}/${f}"
   if [ ! -f "$src" ]; then
     echo "skip ${f} (not found at ${src})" >&2

--- a/bin/sprint.ts
+++ b/bin/sprint.ts
@@ -6,6 +6,7 @@ import { loadLatestArchive } from '../lib/archive.js';
 import { computeTrends } from '../lib/trends.js';
 import { readWip, archiveWip } from '../lib/wip.js';
 import { filterAcceptedCalendarEvents, filterRelevantEmails, windowGithubEvents } from '../lib/filters.js';
+import { appendDayLog } from '../lib/daylog.js';
 
 const [, , subcommand, ...args] = process.argv;
 
@@ -108,6 +109,17 @@ async function main(): Promise<void> {
     case 'archive-wip': {
       const date = requireISODate('--date', flag(args, '--date'));
       out({ archived_to: archiveWip(repoPath(), date) });
+      break;
+    }
+
+    case 'append-day-log': {
+      const date = requireISODate('--date', flag(args, '--date'));
+      const line = (await readStdin()).trim();
+      if (!line) {
+        process.stderr.write('append-day-log requires a non-empty line on stdin\n');
+        process.exit(1);
+      }
+      out({ appended_to: appendDayLog(repoPath(), date, line) });
       break;
     }
 

--- a/day-plan.md
+++ b/day-plan.md
@@ -1,0 +1,94 @@
+Você é um assistente de planejamento diário — roda toda manhã para organizar o dia.
+
+---
+
+## PASSO 1: Inbox
+
+Pergunte ao usuário: "Inbox limpo? (TickTick Inbox + Gmail)"
+
+Se não, liste as tarefas pendentes no Inbox do TickTick (project id: `inbox`) e ajude a triar agora — item a item: mover pra um projeto, agendar, ou descartar — antes de seguir.
+
+---
+
+## PASSO 2: Tarefas do dia
+
+Execute **sem pedir permissão**:
+- `list_undone_tasks_by_time_query` (TickTick) — hoje
+
+Liste as tarefas de hoje. Pergunte: "Quer ajustar algo? (adicionar, remover, repriorizar)" Aplique os ajustes pedidos (`create_task` / `update_task` / `delete_task` conforme o caso).
+
+---
+
+## PASSO 3: Tarefas atrasadas
+
+Execute **sem pedir permissão**:
+- `list_undone_tasks_by_date` (TickTick) — últimos 30 dias até hoje
+
+Filtre as que têm `dueDate` anterior a hoje. Para cada uma, pergunte: fazer hoje, reagendar (pedir nova data), ou abandonar (`update_task` com `status: -1`).
+
+---
+
+## PASSO 4: Calendário + blocos de tempo
+
+Execute **sem pedir permissão**:
+- `gcal_list_events` — hoje
+
+**Filtro obrigatório.** Passe o resultado por `filter-gcal` ANTES de qualquer uso:
+
+```bash
+node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal <<'JSON'
+{aqui-cola-o-JSON-do-MCP}
+JSON
+```
+
+Mostre os eventos confirmados de hoje. Com as tarefas do PASSO 2 (já ajustadas) e os horários livres entre eventos, sugira blocos de tempo para as 1–3 tarefas mais importantes — sem sobrepor os eventos já confirmados. Pergunte se quer criar/ajustar esses blocos no calendário.
+
+---
+
+## PASSO 5: Foco principal (MIT)
+
+Com base nas tarefas e no contexto do sprint (PASSO 6), proponha **1 resultado** que tornaria o dia um sucesso. Pergunte se concorda ou quer trocar.
+
+---
+
+## PASSO 6: Contexto do sprint
+
+Execute **sem pedir permissão**:
+
+```bash
+node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts read-wip --repo <<REPO_PATH>>
+```
+
+Extraia `Projects Priority` e `On my mind` do conteúdo retornado. Mostre brevemente como as tarefas/foco de hoje conectam com a prioridade da semana — ou sinalize se nada do dia está empurrando a prioridade #1 do sprint.
+
+---
+
+## PASSO 7: Goal do dia + papel
+
+Se o foco do PASSO 5 ainda não cobriu isso, pergunte: "Qual é a meta de hoje?"
+
+Depois pergunte: "Pode sincronizar o papel (offline) com essas tarefas agora?" — é só um lembrete, não há ação automatizada aqui.
+
+---
+
+## PASSO 8: Resumo
+
+Exiba um resumo final:
+
+```
+## Plano do dia — [DATA]
+
+Foco principal:
+→ [resultado do PASSO 5]
+
+Prioridades:
+1. [tarefa]
+2. [tarefa]
+3. [tarefa]
+
+Blocos de tempo:
+[HH:MM]–[HH:MM]  [bloco]
+...
+
+Conecta com: [Projects Priority do sprint atual]
+```

--- a/day-plan.md
+++ b/day-plan.md
@@ -6,7 +6,12 @@ Você é um assistente de planejamento diário — roda toda manhã para organiz
 
 Pergunte ao usuário: "Inbox limpo? (TickTick Inbox + Gmail)"
 
-Se não, liste as tarefas pendentes no Inbox do TickTick (project id: `inbox`) e ajude a triar agora — item a item: mover pra um projeto, agendar, ou descartar — antes de seguir.
+Se a TickTick Inbox não estiver limpa, execute **sem pedir permissão**:
+- `get_project_with_undone_tasks` (TickTick, `project_id: inbox`)
+
+Liste as tarefas pendentes e ajude a triar agora — item a item: mover pra um projeto, agendar, ou descartar — antes de seguir.
+
+Se o Gmail não estiver limpo, pergunte quais emails precisam virar tarefa ou resposta e ajude a transformar cada um numa ação concreta (criar task, responder, arquivar) antes de seguir.
 
 ---
 
@@ -22,7 +27,7 @@ Liste as tarefas de hoje. Pergunte: "Quer ajustar algo? (adicionar, remover, rep
 ## PASSO 3: Tarefas atrasadas
 
 Execute **sem pedir permissão**:
-- `list_undone_tasks_by_date` (TickTick) — últimos 30 dias até hoje
+- `list_undone_tasks_by_date` (TickTick) — últimos 14 dias até hoje (máximo permitido pela ferramenta)
 
 Filtre as que têm `dueDate` anterior a hoje. Para cada uma, pergunte: fazer hoje, reagendar (pedir nova data), ou abandonar (`update_task` com `status: -1`).
 
@@ -33,7 +38,9 @@ Filtre as que têm `dueDate` anterior a hoje. Para cada uma, pergunte: fazer hoj
 Execute **sem pedir permissão**:
 - `gcal_list_events` — hoje
 
-**Filtro obrigatório.** Passe o resultado por `filter-gcal` ANTES de qualquer uso:
+**Filtro obrigatório.** Passe o resultado por `filter-gcal` ANTES de qualquer outro uso — inclusive contagem, sumarização ou exibição parcial. Bypass do filtro (ex.: parsear o JSON diretamente em Node one-liner) reintroduz os bugs que o filtro foi criado para evitar.
+
+Passe o JSON via heredoc (evita quoting issues com aspas, backticks, `$`):
 
 ```bash
 node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal <<'JSON'
@@ -45,13 +52,7 @@ Mostre os eventos confirmados de hoje. Com as tarefas do PASSO 2 (já ajustadas)
 
 ---
 
-## PASSO 5: Foco principal (MIT)
-
-Com base nas tarefas e no contexto do sprint (PASSO 6), proponha **1 resultado** que tornaria o dia um sucesso. Pergunte se concorda ou quer trocar.
-
----
-
-## PASSO 6: Contexto do sprint
+## PASSO 5: Contexto do sprint
 
 Execute **sem pedir permissão**:
 
@@ -59,13 +60,19 @@ Execute **sem pedir permissão**:
 node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts read-wip --repo <<REPO_PATH>>
 ```
 
-Extraia `Projects Priority` e `On my mind` do conteúdo retornado. Mostre brevemente como as tarefas/foco de hoje conectam com a prioridade da semana — ou sinalize se nada do dia está empurrando a prioridade #1 do sprint.
+O retorno tem um campo `content` com o texto bruto do `sprint-wip.md`. Extraia `Projects Priority` e `On my mind` desse texto.
+
+---
+
+## PASSO 6: Foco principal (MIT)
+
+Com base nas tarefas (PASSO 2-4) e na prioridade do sprint (PASSO 5), proponha **1 resultado** que tornaria o dia um sucesso, mostrando como ele conecta com a prioridade #1 da semana — ou sinalize se nada do dia está empurrando essa prioridade. Pergunte se o usuário concorda ou quer trocar.
 
 ---
 
 ## PASSO 7: Goal do dia + papel
 
-Se o foco do PASSO 5 ainda não cobriu isso, pergunte: "Qual é a meta de hoje?"
+Se o foco do PASSO 6 ainda não cobriu isso, pergunte: "Qual é a meta de hoje?"
 
 Depois pergunte: "Pode sincronizar o papel (offline) com essas tarefas agora?" — é só um lembrete, não há ação automatizada aqui.
 
@@ -79,7 +86,7 @@ Exiba um resumo final:
 ## Plano do dia — [DATA]
 
 Foco principal:
-→ [resultado do PASSO 5]
+→ [resultado do PASSO 6]
 
 Prioridades:
 1. [tarefa]

--- a/day-wrap.md
+++ b/day-wrap.md
@@ -19,13 +19,13 @@ Execute **sem pedir permissão**:
 node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts read-wip --repo <<REPO_PATH>>
 ```
 
-Extraia `improvement_goals` do frontmatter retornado. Para cada meta, pergunte se foi cumprida hoje (sim/não). Guarde as respostas para o PASSO 7 (log).
+O retorno tem um campo `content` com o texto bruto do `sprint-wip.md` (frontmatter YAML + corpo) — não é um JSON já estruturado. Leia o bloco `improvement_goals:` dentro desse texto. Para cada meta, pergunte se foi cumprida hoje (sim/não). Guarde as respostas para o PASSO 7 (log).
 
 ---
 
 ## PASSO 3: Health do dia
 
-Do mesmo `read-wip`, extraia `health_goals`. Pergunte **separadamente** de Improvements — uma pergunta por meta de Health (ex.: "Meditou hoje?", "Se exercitou hoje?"). É uma tabela distinta no documento do sprint, não misture com o PASSO 2.
+Do mesmo `content` (não rode `read-wip` de novo), leia o bloco `health_goals:`. Pergunte **separadamente** de Improvements — uma pergunta por meta de Health (ex.: "Meditou hoje?", "Se exercitou hoje?"). É uma tabela distinta no documento do sprint, não misture com o PASSO 2.
 
 ---
 
@@ -49,7 +49,9 @@ Mostre a lista. Pergunte: "Quer incluir ou excluir algo?" Aplique os ajustes.
 Execute **sem pedir permissão**:
 - `gcal_list_events` — amanhã
 
-**Filtro obrigatório** (mesma regra do PASSO 4 do `/day-plan`):
+**Filtro obrigatório.** Passe o resultado por `filter-gcal` ANTES de qualquer outro uso — inclusive contagem, sumarização ou exibição parcial. Bypass do filtro (ex.: parsear o JSON diretamente em Node one-liner) reintroduz os bugs que o filtro foi criado para evitar.
+
+Passe o JSON via heredoc (evita quoting issues com aspas, backticks, `$`):
 
 ```bash
 node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal <<'JSON'
@@ -65,15 +67,15 @@ Mostre os eventos confirmados de amanhã. Ajude a encaixar as tarefas do PASSO 5
 
 Pergunte: "Em 1 linha: qual foi o principal output de hoje? Teve algum bloqueio?"
 
-Use o campo `path` retornado pelo `read-wip` do PASSO 2 para achar o diretório de dados (mesmo diretório de `sprint-wip.md`). Acrescente (nunca sobrescreva) uma linha ao arquivo `day-log.md` nesse diretório — crie o arquivo se não existir:
+Monte uma linha juntando a resposta com os resumos dos PASSOs 2 e 3, e grave via `append-day-log` — não use `cat >>`/bash direto, o subcomando já resolve o diretório de dados e evita problemas de quoting com `$`/backticks no texto do usuário:
 
 ```bash
-cat >> "<diretório-de-dados>/day-log.md" <<EOF
-- [DATA]: output: [output do usuário] | blocker: [bloqueio ou "none"] | improvements: [resumo do PASSO 2] | health: [resumo do PASSO 3]
-EOF
+node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts append-day-log --repo <<REPO_PATH>> --date YYYY-MM-DD <<'TEXT'
+output: [output do usuário] | blocker: [bloqueio ou "none"] | improvements: [resumo do PASSO 2] | health: [resumo do PASSO 3]
+TEXT
 ```
 
-Esse log é o que torna a reconstrução do próximo Sprint Review mais leve — reduz a necessidade de varrer TickTick/Calendar/Gmail/transcripts do zero.
+Substitua `YYYY-MM-DD` pela data de hoje. Esse log (`day-log.md`, mesmo diretório de `sprint-wip.md`) é o que torna a reconstrução do próximo Sprint Review mais leve — reduz a necessidade de varrer TickTick/Calendar/Gmail/transcripts do zero.
 
 ---
 

--- a/day-wrap.md
+++ b/day-wrap.md
@@ -1,0 +1,101 @@
+Você é um assistente de wrap diário — roda toda noite para fechar o dia.
+
+---
+
+## PASSO 1: Tarefas concluídas hoje
+
+Execute **sem pedir permissão**:
+- `list_completed_tasks_by_date` (TickTick) — hoje
+
+Mostre a lista. Pergunte: "Bateu tudo que estava planejado? Algo mais que você fez e não está no TickTick?" — adicione e marque como concluído qualquer item mencionado que não apareça na lista.
+
+---
+
+## PASSO 2: Improvements do dia
+
+Execute **sem pedir permissão**:
+
+```bash
+node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts read-wip --repo <<REPO_PATH>>
+```
+
+Extraia `improvement_goals` do frontmatter retornado. Para cada meta, pergunte se foi cumprida hoje (sim/não). Guarde as respostas para o PASSO 7 (log).
+
+---
+
+## PASSO 3: Health do dia
+
+Do mesmo `read-wip`, extraia `health_goals`. Pergunte **separadamente** de Improvements — uma pergunta por meta de Health (ex.: "Meditou hoje?", "Se exercitou hoje?"). É uma tabela distinta no documento do sprint, não misture com o PASSO 2.
+
+---
+
+## PASSO 4: Triagem das tarefas não concluídas
+
+Compare as tarefas planejadas de hoje (do `/day-plan` da manhã, se houver, ou `list_undone_tasks_by_time_query` de hoje) com as concluídas do PASSO 1. Para cada tarefa que sobrou, pergunte: empurrar para amanhã, reagendar para outro dia, ou abandonar. Aplique via `update_task` (`status: -1` para abandonar).
+
+---
+
+## PASSO 5: Tarefas de amanhã
+
+Execute **sem pedir permissão**:
+- `list_undone_tasks_by_time_query` (TickTick) — amanhã
+
+Mostre a lista. Pergunte: "Quer incluir ou excluir algo?" Aplique os ajustes.
+
+---
+
+## PASSO 6: Calendário de amanhã
+
+Execute **sem pedir permissão**:
+- `gcal_list_events` — amanhã
+
+**Filtro obrigatório** (mesma regra do PASSO 4 do `/day-plan`):
+
+```bash
+node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal <<'JSON'
+{aqui-cola-o-JSON-do-MCP}
+JSON
+```
+
+Mostre os eventos confirmados de amanhã. Ajude a encaixar as tarefas do PASSO 5 nos horários livres — pergunte se quer criar/ajustar blocos.
+
+---
+
+## PASSO 7: Log do dia
+
+Pergunte: "Em 1 linha: qual foi o principal output de hoje? Teve algum bloqueio?"
+
+Use o campo `path` retornado pelo `read-wip` do PASSO 2 para achar o diretório de dados (mesmo diretório de `sprint-wip.md`). Acrescente (nunca sobrescreva) uma linha ao arquivo `day-log.md` nesse diretório — crie o arquivo se não existir:
+
+```bash
+cat >> "<diretório-de-dados>/day-log.md" <<EOF
+- [DATA]: output: [output do usuário] | blocker: [bloqueio ou "none"] | improvements: [resumo do PASSO 2] | health: [resumo do PASSO 3]
+EOF
+```
+
+Esse log é o que torna a reconstrução do próximo Sprint Review mais leve — reduz a necessidade de varrer TickTick/Calendar/Gmail/transcripts do zero.
+
+---
+
+## PASSO 8: Mini-reflexão
+
+Pergunte: "O que você faria diferente amanhã?" Anote como 1 bullet — vira insumo direto pra "What could be improved" / "What will I commit to improving" da próxima Sprint Retrospective.
+
+---
+
+## PASSO 9: Resumo
+
+Exiba um resumo final:
+
+```
+## Wrap do dia — [DATA]
+
+Concluído: [N tarefas]
+Improvements: [resumo]
+Health: [resumo]
+Output principal: [output]
+Bloqueio: [bloqueio ou nenhum]
+Amanhã: [N tarefas + foco]
+
+Reflexão: [bullet do PASSO 8]
+```

--- a/lib/daylog.ts
+++ b/lib/daylog.ts
@@ -1,0 +1,23 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { sprintsDir } from './paths.js';
+
+/**
+ * Appends one line to `day-log.md` in the sprint data directory. Used by
+ * `/day-wrap` to leave a running record (output + blocker) that the next
+ * `/sprint-start` can read instead of reconstructing the week from scratch.
+ *
+ * Writing happens entirely in Node (not shell `cat >>`) so the line's
+ * free-text content is never subject to shell expansion — the caller
+ * supplies the already-assembled line, this function only adds the leading
+ * date stamp and a trailing newline.
+ */
+export function appendDayLog(repoPath: string, date: string, line: string): string {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) throw new Error(`Invalid date: ${date}`);
+  const dir = sprintsDir(repoPath);
+  fs.mkdirSync(dir, { recursive: true });
+  const dest = path.join(dir, 'day-log.md');
+  const entry = `- [${date}]: ${line.trim()}\n`;
+  fs.appendFileSync(dest, entry);
+  return dest;
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "check-sync": "node build.js --check",
     "install-skills": "bash bin/install-skills.sh",
     "check-skills": "bash bin/check-skills.sh",
-    "test": "node --test __tests__/parser.test.js __tests__/insert.test.js __tests__/skill-checks.test.js && node -r tsx/cjs --test __tests__/period.test.ts __tests__/archive.test.ts __tests__/trends.test.ts __tests__/wip.test.ts __tests__/document.test.ts __tests__/paths.test.ts __tests__/filters.test.ts __tests__/cli.test.ts"
+    "test": "node --test __tests__/parser.test.js __tests__/insert.test.js __tests__/skill-checks.test.js && node -r tsx/cjs --test __tests__/period.test.ts __tests__/archive.test.ts __tests__/trends.test.ts __tests__/wip.test.ts __tests__/document.test.ts __tests__/paths.test.ts __tests__/filters.test.ts __tests__/cli.test.ts __tests__/daylog.test.ts"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary
- Adds `/day-plan` (morning: inbox triage, today's tasks, overdue triage, calendar-aware time blocks, 1 main focus tied to the active sprint's Projects Priority) and `/day-wrap` (evening: completion review, separate Improvement/Health check-ins, undone-task triage, tomorrow planning, a `day-log.md` entry, mini-reflection)
- Registers both in `bin/install-skills.sh` and `bin/check-skills.sh` alongside the existing `sprint-*` skills
- Updates `__tests__/skill-checks.test.js` fixtures and README with a "Daily companions" section

## Test plan
- [x] `npm run install-skills` materializes both files cleanly (no leftover `<<REPO_PATH>>` tokens)
- [x] `npm test` — 110/110 passing, including `check-skills.sh passes against the live skill files`
- [ ] Manual run of `/day-plan` and `/day-wrap` against real TickTick/Calendar data (not yet exercised end-to-end)

Closes #80, closes #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163nB6ee7tAwTK6foCy9Qmb