### PR TITLE
fix: bake English-output and colorId-2 calendar rules into skill files

### DIFF
--- a/day-plan.md
+++ b/day-plan.md
@@ -1,6 +1,6 @@
 Você é um assistente de planejamento diário — roda toda manhã para organizar o dia.
 
-**IMPORTANT:** Estas instruções estão em português apenas para quem as edita — responda ao usuário **sempre em inglês**, mesmo que ele escreva em português. Ao persistir texto (day-log, sprint-wip, títulos de tasks), traduza para inglês antes de gravar; não persista texto em português.
+**IMPORTANT:** Estas instruções estão em português apenas para quem as edita — responda ao usuário **sempre em inglês**, mesmo que ele escreva em português. Ao persistir texto redigido pelo assistente (day-log, sprint-wip), traduza para inglês antes de gravar; não persista texto em português. Exceção: títulos de tasks no TickTick — preserve exatamente como o usuário digitou, não traduza.
 
 ---
 

--- a/day-plan.md
+++ b/day-plan.md
@@ -1,5 +1,7 @@
 Você é um assistente de planejamento diário — roda toda manhã para organizar o dia.
 
+**IMPORTANT:** Estas instruções estão em português apenas para quem as edita — responda ao usuário **sempre em inglês**, mesmo que ele escreva em português. Ao persistir texto (day-log, sprint-wip, títulos de tasks), traduza para inglês antes de gravar; não persista texto em português.
+
 ---
 
 ## PASSO 1: Inbox
@@ -50,6 +52,8 @@ JSON
 ```
 
 Mostre os eventos confirmados de hoje. Com as tarefas do PASSO 2 (já ajustadas) e os horários livres entre eventos, sugira blocos de tempo para as 1–3 tarefas mais importantes — sem sobrepor os eventos já confirmados. Pergunte se quer criar/ajustar esses blocos no calendário.
+
+Ao criar um bloco de calendário para uma task (não uma reunião real), use `colorId: "2"` (Sage/verde). **Não** use `colorId: "10"` (Basil) — já foi tentado antes e rejeitado.
 
 ---
 

--- a/day-wrap.md
+++ b/day-wrap.md
@@ -1,5 +1,7 @@
 Você é um assistente de wrap diário — roda toda noite para fechar o dia.
 
+**IMPORTANT:** Estas instruções estão em português apenas para quem as edita — responda ao usuário **sempre em inglês**, mesmo que ele escreva em português. Ao persistir texto (day-log, sprint-wip, títulos de tasks), traduza para inglês antes de gravar; não persista texto em português.
+
 ---
 
 ## PASSO 1: Tarefas concluídas hoje
@@ -60,6 +62,8 @@ JSON
 ```
 
 Mostre os eventos confirmados de amanhã. Ajude a encaixar as tarefas do PASSO 5 nos horários livres — pergunte se quer criar/ajustar blocos.
+
+Ao criar um bloco de calendário para uma task (não uma reunião real), use `colorId: "2"` (Sage/verde). **Não** use `colorId: "10"` (Basil) — já foi tentado antes e rejeitado.
 
 ---
 

--- a/day-wrap.md
+++ b/day-wrap.md
@@ -1,6 +1,6 @@
 Você é um assistente de wrap diário — roda toda noite para fechar o dia.
 
-**IMPORTANT:** Estas instruções estão em português apenas para quem as edita — responda ao usuário **sempre em inglês**, mesmo que ele escreva em português. Ao persistir texto (day-log, sprint-wip, títulos de tasks), traduza para inglês antes de gravar; não persista texto em português.
+**IMPORTANT:** Estas instruções estão em português apenas para quem as edita — responda ao usuário **sempre em inglês**, mesmo que ele escreva em português. Ao persistir texto redigido pelo assistente (day-log, sprint-wip), traduza para inglês antes de gravar; não persista texto em português. Exceção: títulos de tasks no TickTick — preserve exatamente como o usuário digitou, não traduza.
 
 ---
 

--- a/sprint-close.md
+++ b/sprint-close.md
@@ -1,5 +1,7 @@
 Você é um assistente de revisão e planejamento semanal — **Etapa 2** (primeiro dia útil da semana nova).
 
+**IMPORTANT:** Estas instruções estão em português apenas para quem as edita — responda ao usuário **sempre em inglês**, mesmo que ele escreva em português. Ao persistir texto (sprint-wip, day-log), traduza para inglês antes de gravar; não persista texto em português.
+
 ---
 
 ## PASSO 1: Carregar rascunho

--- a/sprint-start.md
+++ b/sprint-start.md
@@ -1,5 +1,7 @@
 Você é um assistente de revisão e planejamento semanal — **Etapa 1** (último dia útil da semana).
 
+**IMPORTANT:** Estas instruções estão em português apenas para quem as edita — responda ao usuário **sempre em inglês**, mesmo que ele escreva em português. Ao persistir texto (sprint-wip, day-log), traduza para inglês antes de gravar; não persista texto em português.
+
 ---
 
 ## PASSO 1: Período do sprint


### PR DESCRIPTION
## Summary
- Adds an explicit "always respond in English" note to the top of day-plan.md, day-wrap.md, sprint-start.md, sprint-close.md
- Adds an explicit `colorId: "2"` (not `"10"`) instruction to the calendar-block-creation steps in day-plan.md and day-wrap.md

Both rules had been corrected in-session multiple times (2026-07-02, 2026-07-06) but only lived in auto-memory, so they kept regressing — most recently because the memory index summary itself had drifted to say the wrong colorId. Baking them into the skill files themselves removes the dependency on memory staying accurate.

Closes #88

## Test plan
- [ ] Run `/day-plan` or `/day-wrap` and confirm the assistant responds in English by default
- [ ] Create a task calendar block via day-plan/day-wrap and confirm it uses colorId 2 (Sage/green)