### PR TITLE
fix: day-plan restructure + calendar RSVP filter + PASSO->STEP rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,14 @@ See [SETUP.md](SETUP.md) for complete configuration instructions.
 ## Setup
 
 1. **Install the skill files** with `npm run install-skills` (or `bash bin/install-skills.sh`) — the script substitutes the `<<REPO_PATH>>` placeholder with your clone's path and writes the result to `~/.claude/commands/`. See [SETUP.md → Step 6](SETUP.md#step-6-install-skill-files) for details.
-2. **Adapt the project list** — the shipped `sprint-start.md` PASSO 4a/4c includes the maintainer's own projects (Diar.ia, Clarice, Jandig, …) as concrete examples. Replace those project names with your own; the Outputs/Outcomes structure stays.
+2. **Adapt the project list** — the shipped `sprint-start.md` STEP 4a/4c includes the maintainer's own projects (Diar.ia, Clarice, Jandig, …) as concrete examples. Replace those project names with your own; the Outputs/Outcomes structure stays.
 3. **Adjust the improvement goals** if yours differ from the defaults (`Work +2h`, `OoH`, `Make impact`).
 
 For the full Drive-upload setup (OAuth, Apps Script, `.env`), see [SETUP.md](SETUP.md).
 
 ## Document format
 
-The exact structure of the generated document — Review/Retrospective/Planning sections, Outputs/Outcomes rules, table layouts — is defined by the skill files themselves. Rather than mirror it here (and risk drift), see [`sprint-start.md`](sprint-start.md) for the authoritative templates: PASSO 4a (Review), PASSO 4b (Retrospective), and PASSO 4c (Planning).
+The exact structure of the generated document — Review/Retrospective/Planning sections, Outputs/Outcomes rules, table layouts — is defined by the skill files themselves. Rather than mirror it here (and risk drift), see [`sprint-start.md`](sprint-start.md) for the authoritative templates: STEP 4a (Review), STEP 4b (Retrospective), and STEP 4c (Planning).
 
 ## Notes
 

--- a/day-plan.md
+++ b/day-plan.md
@@ -4,60 +4,7 @@ Você é um assistente de planejamento diário — roda toda manhã para organiz
 
 ---
 
-## PASSO 1: Inbox
-
-Execute **sem pedir permissão, sem perguntar antes**:
-- `get_project_with_undone_tasks` (TickTick, `project_id: inbox`)
-- Gmail: busque mensagens não lidas/pendentes na inbox (ex.: `is:unread in:inbox`)
-
-Se ambos vierem vazios, informe "Inbox TickTick + Gmail limpos" e siga direto para o PASSO 2 — não pergunte "Inbox limpo?" primeiro.
-
-Se a TickTick Inbox tiver itens, liste-os e ajude a triar agora — item a item: mover pra um projeto, agendar, ou descartar.
-
-Se o Gmail tiver itens pendentes, liste-os e ajude a transformar cada um numa ação concreta (criar task, responder, arquivar) — antes de seguir.
-
----
-
-## PASSO 2: Tarefas do dia
-
-Execute **sem pedir permissão**:
-- `list_undone_tasks_by_time_query` (TickTick) — hoje
-
-Liste as tarefas de hoje. Pergunte: "Quer ajustar algo? (adicionar, remover, repriorizar)" Aplique os ajustes pedidos (`create_task` / `update_task` / `delete_task` conforme o caso).
-
----
-
-## PASSO 3: Tarefas atrasadas
-
-Execute **sem pedir permissão**:
-- `list_undone_tasks_by_date` (TickTick) — últimos 14 dias até hoje (máximo permitido pela ferramenta)
-
-Filtre as que têm `dueDate` anterior a hoje. Para cada uma, pergunte: fazer hoje, reagendar (pedir nova data), ou abandonar (`update_task` com `status: -1`).
-
----
-
-## PASSO 4: Calendário + blocos de tempo
-
-Execute **sem pedir permissão**:
-- `gcal_list_events` — hoje
-
-**Filtro obrigatório.** Passe o resultado por `filter-gcal` ANTES de qualquer outro uso — inclusive contagem, sumarização ou exibição parcial. Bypass do filtro (ex.: parsear o JSON diretamente em Node one-liner) reintroduz os bugs que o filtro foi criado para evitar.
-
-Passe o JSON via heredoc (evita quoting issues com aspas, backticks, `$`):
-
-```bash
-node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal <<'JSON'
-{aqui-cola-o-JSON-do-MCP}
-JSON
-```
-
-Mostre os eventos confirmados de hoje. Com as tarefas do PASSO 2 (já ajustadas) e os horários livres entre eventos, sugira blocos de tempo para as 1–3 tarefas mais importantes — sem sobrepor os eventos já confirmados. Pergunte se quer criar/ajustar esses blocos no calendário.
-
-Ao criar um bloco de calendário para uma task (não uma reunião real), use `colorId: "2"` (Sage/verde). **Não** use `colorId: "10"` (Basil) — já foi tentado antes e rejeitado.
-
----
-
-## PASSO 5: Contexto do sprint
+## STEP 1: Metas do sprint
 
 Execute **sem pedir permissão**:
 
@@ -65,42 +12,102 @@ Execute **sem pedir permissão**:
 node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts read-wip --repo <<REPO_PATH>>
 ```
 
-O retorno tem um campo `content` com o texto bruto do `sprint-wip.md`. Extraia `Projects Priority` e `On my mind` desse texto.
+O retorno tem um campo `content` com o texto bruto do `sprint-wip.md` (frontmatter YAML + corpo). Extraia `improvement_goals` e `health_goals` do frontmatter e mostre como lembrete rápido — 1-2 linhas cada, sem re-derivar as tabelas completas do Sprint Planning:
+
+```
+Improvements this week: [improvement_goals[] resumidos em 1 linha]
+Health goals this week: [health_goals{} resumidos em 1 linha]
+```
+
+Guarde o `content` retornado — reutilize no STEP 5 (Contexto do sprint) para extrair `Projects Priority` e `On my mind`, sem chamar `read-wip` de novo.
 
 ---
 
-## PASSO 6: Foco principal (MIT)
+## STEP 2: Inbox
 
-Com base nas tarefas (PASSO 2-4) e na prioridade do sprint (PASSO 5), proponha **1 resultado** que tornaria o dia um sucesso, mostrando como ele conecta com a prioridade #1 da semana — ou sinalize se nada do dia está empurrando essa prioridade. Pergunte se o usuário concorda ou quer trocar.
+Execute **sem pedir permissão, sem perguntar antes**:
+- `get_project_with_undone_tasks` (TickTick, `project_id: inbox`)
+- Gmail: busque mensagens não lidas/pendentes na inbox (ex.: `is:unread in:inbox`)
+
+Se ambos vierem vazios, informe "Inbox TickTick + Gmail limpos" e siga direto para o STEP 3 — não pergunte "Inbox limpo?" primeiro.
+
+Se a TickTick Inbox tiver itens, liste-os e ajude a triar agora — item a item: mover pra um projeto, agendar, ou descartar.
+
+Se o Gmail tiver itens pendentes, liste-os e ajude a transformar cada um numa ação concreta (criar task, responder, arquivar) — antes de seguir.
 
 ---
 
-## PASSO 7: Goal do dia + papel
+## STEP 3: Tarefas do dia
 
-Se o foco do PASSO 6 ainda não cobriu isso, pergunte: "Qual é a meta de hoje?"
+Execute **sem pedir permissão**:
+- `list_undone_tasks_by_time_query` (TickTick) — hoje
+- `list_undone_tasks_by_date` (TickTick) — últimos 14 dias até hoje (máximo permitido pela ferramenta)
+
+Filtre as atrasadas dentro do segundo resultado (as que têm `dueDate` anterior a hoje).
+
+Liste juntas as tarefas de hoje e as atrasadas, marcando claramente quais são atrasadas. Para as tarefas de hoje, pergunte: "Quer ajustar algo? (adicionar, remover, repriorizar)" Para cada tarefa atrasada, pergunte: fazer hoje, reagendar (pedir nova data), ou abandonar (`update_task` com `status: -1`). Aplique os ajustes pedidos (`create_task` / `update_task` / `delete_task` conforme o caso).
+
+---
+
+## STEP 4: Calendário + blocos de tempo
+
+Execute **sem pedir permissão**:
+- `gcal_list_events` — hoje
+
+**Filtro obrigatório.** Antes de montar o JSON, calcule `myResponseStatus` em cada evento: use o `responseStatus` do attendee com `self: true`; se o evento não tiver `attendees` (sem convidados, criado pelo próprio usuário), trate como `"accepted"`. Passe o resultado por `filter-gcal` ANTES de qualquer outro uso — inclusive contagem, sumarização ou exibição parcial (o subcomando descarta eventos cujo `myResponseStatus` não seja `accepted` — convites ainda não respondidos não entram na lista). Bypass do filtro (ex.: parsear o JSON diretamente em Node one-liner) reintroduz os bugs que o filtro foi criado para evitar.
+
+Passe o JSON via heredoc (evita quoting issues com aspas, backticks, `$`):
+
+```bash
+node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal <<'JSON'
+{aqui-cola-o-JSON-do-MCP, cada evento já com myResponseStatus}
+JSON
+```
+
+Mostre os eventos confirmados de hoje. Com as tarefas do STEP 3 (já ajustadas) e os horários livres entre eventos, sugira blocos de tempo para as 1–3 tarefas mais importantes — sem sobrepor os eventos já confirmados. Pergunte se quer criar/ajustar esses blocos no calendário.
+
+Ao criar um bloco de calendário para uma task (não uma reunião real), use `colorId: "2"` (Sage/verde). **Não** use `colorId: "10"` (Basil) — já foi tentado antes e rejeitado.
+
+---
+
+## STEP 5: Contexto do sprint
+
+Use o `content` já obtido no STEP 1 (não chame `read-wip` de novo). Extraia `Projects Priority` e `On my mind` desse texto.
+
+---
+
+## STEP 6: Foco principal (MIT)
+
+Com base nas tarefas (STEP 3-4) e na prioridade do sprint (STEP 5), proponha **1 resultado** que tornaria o dia um sucesso, mostrando como ele conecta com a prioridade #1 da semana — ou sinalize se nada do dia está empurrando essa prioridade. Pergunte se o usuário concorda ou quer trocar.
+
+---
+
+## STEP 7: Goal do dia + papel
+
+Se o foco do STEP 6 ainda não cobriu isso, pergunte: "Qual é a meta de hoje?"
 
 Depois pergunte: "Pode sincronizar o papel (offline) com essas tarefas agora?" — é só um lembrete, não há ação automatizada aqui.
 
 ---
 
-## PASSO 8: Resumo
+## STEP 8: Resumo
 
-Exiba um resumo final:
+Exiba um resumo final, com a lista **completa** das tarefas do dia (STEP 3, já ajustadas) — não apenas as 3 principais:
 
 ```
-## Plano do dia — [DATA]
+## Day plan — [DATA]
 
-Foco principal:
-→ [resultado do PASSO 6]
+Main focus:
+→ [resultado do STEP 6]
 
-Prioridades:
+Today's tasks:
 1. [tarefa]
 2. [tarefa]
-3. [tarefa]
+...
 
-Blocos de tempo:
+Time blocks:
 [HH:MM]–[HH:MM]  [bloco]
 ...
 
-Conecta com: [Projects Priority do sprint atual]
+Connects with: [Projects Priority do sprint atual]
 ```

--- a/day-wrap.md
+++ b/day-wrap.md
@@ -4,7 +4,7 @@ Você é um assistente de wrap diário — roda toda noite para fechar o dia.
 
 ---
 
-## PASSO 1: Tarefas concluídas hoje
+## STEP 1: Tarefas concluídas hoje
 
 Execute **sem pedir permissão**:
 - `list_completed_tasks_by_date` (TickTick) — hoje
@@ -13,7 +13,7 @@ Mostre a lista. Pergunte: "Bateu tudo que estava planejado? Algo mais que você 
 
 ---
 
-## PASSO 2: Improvements do dia
+## STEP 2: Improvements do dia
 
 Execute **sem pedir permissão**:
 
@@ -21,23 +21,23 @@ Execute **sem pedir permissão**:
 node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts read-wip --repo <<REPO_PATH>>
 ```
 
-O retorno tem um campo `content` com o texto bruto do `sprint-wip.md` (frontmatter YAML + corpo) — não é um JSON já estruturado. Leia o bloco `improvement_goals:` dentro desse texto. Para cada meta, pergunte se foi cumprida hoje (sim/não). Guarde as respostas para o PASSO 7 (log).
+O retorno tem um campo `content` com o texto bruto do `sprint-wip.md` (frontmatter YAML + corpo) — não é um JSON já estruturado. Leia o bloco `improvement_goals:` dentro desse texto. Para cada meta, pergunte se foi cumprida hoje (sim/não). Guarde as respostas para o STEP 7 (log).
 
 ---
 
-## PASSO 3: Health do dia
+## STEP 3: Health do dia
 
-Do mesmo `content` (não rode `read-wip` de novo), leia o bloco `health_goals:`. Pergunte **separadamente** de Improvements — uma pergunta por meta de Health (ex.: "Meditou hoje?", "Se exercitou hoje?"). É uma tabela distinta no documento do sprint, não misture com o PASSO 2.
-
----
-
-## PASSO 4: Triagem das tarefas não concluídas
-
-Compare as tarefas planejadas de hoje (do `/day-plan` da manhã, se houver, ou `list_undone_tasks_by_time_query` de hoje) com as concluídas do PASSO 1. Para cada tarefa que sobrou, pergunte: empurrar para amanhã, reagendar para outro dia, ou abandonar. Aplique via `update_task` (`status: -1` para abandonar).
+Do mesmo `content` (não rode `read-wip` de novo), leia o bloco `health_goals:`. Pergunte **separadamente** de Improvements — uma pergunta por meta de Health (ex.: "Meditou hoje?", "Se exercitou hoje?"). É uma tabela distinta no documento do sprint, não misture com o STEP 2.
 
 ---
 
-## PASSO 5: Tarefas de amanhã
+## STEP 4: Triagem das tarefas não concluídas
+
+Compare as tarefas planejadas de hoje (do `/day-plan` da manhã, se houver, ou `list_undone_tasks_by_time_query` de hoje) com as concluídas do STEP 1. Para cada tarefa que sobrou, pergunte: empurrar para amanhã, reagendar para outro dia, ou abandonar. Aplique via `update_task` (`status: -1` para abandonar).
+
+---
+
+## STEP 5: Tarefas de amanhã
 
 Execute **sem pedir permissão**:
 - `list_undone_tasks_by_time_query` (TickTick) — amanhã
@@ -46,36 +46,36 @@ Mostre a lista. Pergunte: "Quer incluir ou excluir algo?" Aplique os ajustes.
 
 ---
 
-## PASSO 6: Calendário de amanhã
+## STEP 6: Calendário de amanhã
 
 Execute **sem pedir permissão**:
 - `gcal_list_events` — amanhã
 
-**Filtro obrigatório.** Passe o resultado por `filter-gcal` ANTES de qualquer outro uso — inclusive contagem, sumarização ou exibição parcial. Bypass do filtro (ex.: parsear o JSON diretamente em Node one-liner) reintroduz os bugs que o filtro foi criado para evitar.
+**Filtro obrigatório.** Antes de montar o JSON, calcule `myResponseStatus` em cada evento: use o `responseStatus` do attendee com `self: true`; se o evento não tiver `attendees` (sem convidados, criado pelo próprio usuário), trate como `"accepted"`. Passe o resultado por `filter-gcal` ANTES de qualquer outro uso — inclusive contagem, sumarização ou exibição parcial (o subcomando descarta eventos cujo `myResponseStatus` não seja `accepted` — convites ainda não respondidos não entram na lista). Bypass do filtro (ex.: parsear o JSON diretamente em Node one-liner) reintroduz os bugs que o filtro foi criado para evitar.
 
 Passe o JSON via heredoc (evita quoting issues com aspas, backticks, `$`):
 
 ```bash
 node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal <<'JSON'
-{aqui-cola-o-JSON-do-MCP}
+{aqui-cola-o-JSON-do-MCP, cada evento já com myResponseStatus}
 JSON
 ```
 
-Mostre os eventos confirmados de amanhã. Ajude a encaixar as tarefas do PASSO 5 nos horários livres — pergunte se quer criar/ajustar blocos.
+Mostre os eventos confirmados de amanhã. Ajude a encaixar as tarefas do STEP 5 nos horários livres — pergunte se quer criar/ajustar blocos.
 
 Ao criar um bloco de calendário para uma task (não uma reunião real), use `colorId: "2"` (Sage/verde). **Não** use `colorId: "10"` (Basil) — já foi tentado antes e rejeitado.
 
 ---
 
-## PASSO 7: Log do dia
+## STEP 7: Log do dia
 
 Pergunte: "Em 1 linha: qual foi o principal output de hoje? Teve algum bloqueio?"
 
-Monte uma linha juntando a resposta com os resumos dos PASSOs 2 e 3, e grave via `append-day-log` — não use `cat >>`/bash direto, o subcomando já resolve o diretório de dados e evita problemas de quoting com `$`/backticks no texto do usuário:
+Monte uma linha juntando a resposta com os resumos dos STEPs 2 e 3, e grave via `append-day-log` — não use `cat >>`/bash direto, o subcomando já resolve o diretório de dados e evita problemas de quoting com `$`/backticks no texto do usuário:
 
 ```bash
 node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts append-day-log --repo <<REPO_PATH>> --date YYYY-MM-DD <<'TEXT'
-output: [output do usuário] | blocker: [bloqueio ou "none"] | improvements: [resumo do PASSO 2] | health: [resumo do PASSO 3]
+output: [output do usuário] | blocker: [bloqueio ou "none"] | improvements: [resumo do STEP 2] | health: [resumo do STEP 3]
 TEXT
 ```
 
@@ -83,25 +83,29 @@ Substitua `YYYY-MM-DD` pela data de hoje. Esse log (`day-log.md`, mesmo diretór
 
 ---
 
-## PASSO 8: Mini-reflexão
+## STEP 8: Mini-reflexão
 
 Pergunte: "O que você faria diferente amanhã?" Anote como 1 bullet — vira insumo direto pra "What could be improved" / "What will I commit to improving" da próxima Sprint Retrospective.
 
 ---
 
-## PASSO 9: Resumo
+## STEP 9: Resumo
 
-Exiba um resumo final:
+Exiba um resumo final, com a lista **completa** das tarefas de amanhã (STEP 5, já ajustadas) — não apenas uma contagem:
 
 ```
-## Wrap do dia — [DATA]
+## Day wrap — [DATA]
 
-Concluído: [N tarefas]
-Improvements: [resumo]
-Health: [resumo]
-Output principal: [output]
-Bloqueio: [bloqueio ou nenhum]
-Amanhã: [N tarefas + foco]
+Completed: [N tasks]
+Improvements: [summary]
+Health: [summary]
+Main output: [output]
+Blocker: [blocker or none]
 
-Reflexão: [bullet do PASSO 8]
+Tomorrow's tasks:
+1. [tarefa]
+2. [tarefa]
+...
+
+Reflection: [bullet do STEP 8]
 ```

--- a/sprint-close.md
+++ b/sprint-close.md
@@ -4,7 +4,7 @@ Você é um assistente de revisão e planejamento semanal — **Etapa 2** (prime
 
 ---
 
-## PASSO 1: Carregar rascunho
+## STEP 1: Carregar rascunho
 
 Execute **sem pedir permissão**:
 
@@ -17,7 +17,7 @@ Informe ao usuário: "Encontrei o rascunho do sprint [period]. Vou coletar os da
 
 ---
 
-## PASSO 2: Completar dados automaticamente
+## STEP 2: Completar dados automaticamente
 
 Execute em paralelo **sem pedir permissão** (período = `generated_at` do rascunho até agora, para capturar trabalho do fim de semana e dias de gap):
 - `list_completed_tasks_by_date` (TickTick) — da data de geração do rascunho até agora
@@ -25,13 +25,13 @@ Execute em paralelo **sem pedir permissão** (período = `generated_at` do rascu
 - `gmail_search_messages` — mesmo período
 - **Claude Code transcripts** — `find ~/.claude/projects/ -maxdepth 2 -name "*.jsonl" -newermt 'generated_at'` (substitua a data literalmente em formato `YYYY-MM-DD`). Por sessão, extraia: objetivo, resultado, PRs/issues referenciados. **Delegue a um subagente Explore.**
 
-**Filtro obrigatório.** Após cada chamada MCP (`gcal_list_events`, `gmail_search_messages`), passe o resultado pelo subcomando correspondente ANTES de qualquer outro uso. Bypass do filtro reintroduz os bugs que ele foi criado para evitar.
+**Filtro obrigatório.** Após cada chamada MCP (`gcal_list_events`, `gmail_search_messages`), passe o resultado pelo subcomando correspondente ANTES de qualquer outro uso. Para `gcal_list_events`, calcule primeiro `myResponseStatus` em cada evento (`responseStatus` do attendee com `self: true`; sem `attendees` → trate como `"accepted"`) — é esse campo que `filter-gcal` usa para descartar convites ainda não respondidos. Bypass do filtro reintroduz os bugs que ele foi criado para evitar.
 
 Para os filtros, passe o JSON via heredoc:
 
 ```bash
 node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal <<'JSON'
-{aqui-cola-o-JSON-do-MCP}
+{aqui-cola-o-JSON-do-MCP, cada evento já com myResponseStatus}
 JSON
 ```
 
@@ -39,13 +39,13 @@ Use `filter-gmail` da mesma forma. Cada comando lê do stdin e retorna o array f
 
 ---
 
-## PASSO 3: Dados do papel
+## STEP 3: Dados do papel
 
-Antes de perguntar qualquer coisa, releia o rascunho já carregado no PASSO 1 (frontmatter + tabelas da Retro) e identifique exatamente o que falta:
+Antes de perguntar qualquer coisa, releia o rascunho já carregado no STEP 1 (frontmatter + tabelas da Retro) e identifique exatamente o que falta:
 - Os labels dos improvement goals vêm de `improvement_goals[]` do frontmatter — **nunca** use um template genérico com labels fixos que não sejam os que estão de fato no rascunho.
 - O denominador de cada linha é `review_workdays` do frontmatter.
 - Se uma linha da tabela "Last week's improvement goals" ou "Health goals" já tiver um resultado preenchido (não `[PENDING]`), não pergunte de novo — só inclua na mensagem se for genuinamente `[PENDING]` ou estiver faltando.
-- As **"Metas para a semana que começa hoje" não são dados novos** — já são `improvement_goals[]` / `health_goals{}` do frontmatter, escritos pelo `/sprint-start` (PASSO 4c) que gerou este rascunho. Não peça para o usuário redefini-las: apenas quote-as de volta para confirmação.
+- As **"Metas para a semana que começa hoje" não são dados novos** — já são `improvement_goals[]` / `health_goals{}` do frontmatter, escritos pelo `/sprint-start` (STEP 4c) que gerou este rascunho. Não peça para o usuário redefini-las: apenas quote-as de volta para confirmação.
 
 Envie em **uma única mensagem**, usando os labels/denominadores reais do rascunho e perguntando só pelo que estiver genuinamente pendente:
 
@@ -64,13 +64,13 @@ Coletei os dados que faltaram. Só preciso confirmar o que ainda está pendente 
 
 ---
 
-## PASSO 4: Documento final
+## STEP 4: Documento final
 
 Mescle o rascunho com os novos dados:
 - Substitua todos os `[PENDING]` pelos valores reais
-- **Remova a seção `## Plano do dia`** (snapshot da manhã, herdado do `/sprint-start`) — o documento fechado deve conter só Review / Retro / Planning. O `archive-wip` (PASSO 7) também remove essa seção automaticamente, então isso é uma rede de segurança (#73)
+- **Remova a seção `## Plano do dia`** (snapshot da manhã, herdado do `/sprint-start`) — o documento fechado deve conter só Review / Retro / Planning. O `archive-wip` (STEP 7) também remove essa seção automaticamente, então isso é uma rede de segurança (#73)
 - Adicione os novos Outputs/Outcomes do fim de semana
-- Complete as seções narrativas (What could be improved, What will I commit) se ainda pendentes — em **estilo scrum** (bullets curtos e acionáveis; o "commit" é um action item concreto e rastreável, conforme `/sprint-start` PASSO 4b)
+- Complete as seções narrativas (What could be improved, What will I commit) se ainda pendentes — em **estilo scrum** (bullets curtos e acionáveis; o "commit" é um action item concreto e rastreável, conforme `/sprint-start` STEP 4b)
 - Ajuste o Sprint Planning se necessário
 - Mantenha o **frontmatter YAML** do topo em sincronia com os valores finais do Planning (`improvement_goals`, `health_goals`, `on_my_mind`, `on_hold`) — é o que o próximo `/sprint-start` lê via `bin/sprint.ts archive`
 - Ao preencher os `[PENDING]` da Retro, grave também os **resultados no frontmatter** (lidos pelo `bin/sprint.ts trends` e pelo dashboard Obsidian):
@@ -91,7 +91,7 @@ Entregue o documento final limpo (sem `[PENDING]`, sem comentários), **no mesmo
 
 ---
 
-## PASSO 5: Revisão rápida
+## STEP 5: Revisão rápida
 
 Faça apenas 2 perguntas em uma mensagem:
 1. "Algo faltou nos **Outcomes** ou **Outputs** do fim de semana?"
@@ -101,7 +101,7 @@ Incorpore o feedback e entregue a versão final pronta para copiar para o Google
 
 ---
 
-## PASSO 6: Tarefas focadas da semana
+## STEP 6: Tarefas focadas da semana
 
 Com o Planning já confirmado (Projects Priority + Outcomes), traduza isso num pequeno conjunto de tarefas concretas para a semana:
 
@@ -110,13 +110,13 @@ Com o Planning já confirmado (Projects Priority + Outcomes), traduza isso num p
 3. Não aplique um corte uniforme de "N tarefas" para todas as prioridades. Distinga dois casos:
    - **Outcome é "fechar uma checklist específica"** (ex.: "Health → todos os exames/consultas agendados") → liste **todas** as tarefas abertas que batem com aquele Outcome, mesmo que sejam muitas — cortar aqui derruba itens que o próprio Outcome exige.
    - **Prioridade com backlog grande e aberto** (ex.: Diar.ia com dezenas de tarefas soltas) → aplique o mesmo corte de "top 3 por prioridade" usado nos Outputs (ranqueie o que empurra a prioridade da semana).
-4. Antes de propor a lista, verifique se algum item já foi de fato concluído em sessões recentes mesmo que ainda apareça como aberto no TickTick (cruze com o que já foi levantado no PASSO 2 — transcripts, emails, changelogs). TickTick pode estar desatualizado; não presuma que "status aberto" = "ainda não feito".
+4. Antes de propor a lista, verifique se algum item já foi de fato concluído em sessões recentes mesmo que ainda apareça como aberto no TickTick (cruze com o que já foi levantado no STEP 2 — transcripts, emails, changelogs). TickTick pode estar desatualizado; não presuma que "status aberto" = "ainda não feito".
 5. Proponha o conjunto resultante ao usuário para confirmar, ajustar ou rejeitar — no mesmo espírito de como o day-plan propõe o MIT diário.
 6. Registre o conjunto acordado no documento (nova seção "Focus tasks for the week" dentro do Sprint Planning) para ficar visível durante a semana e ser conferido no próximo `/sprint-close`.
 
 ---
 
-## PASSO 7: Salvar e arquivar
+## STEP 7: Salvar e arquivar
 
 Após a versão final estar aprovada:
 
@@ -129,7 +129,7 @@ node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts archive-wip --repo <<REPO_PATH>> --d
 
 O comando cria `.sprints/archive/<DATA>.md` (sobrescreve em reruns do mesmo ciclo — intencional). Ele também **remove a seção `## Plano do dia`** do `sprint-wip.md` e da cópia arquivada (operação idempotente), garantindo que tanto o arquivo quanto o que sobe pro Google Doc fiquem só com Review / Retro / Planning (#73).
 
-O arquivo arquivado é a **fonte de contexto** que `/sprint-start` (PASSO 1b) lê na próxima sexta para preservar "On my mind", "On hold" e metas de Health entre sprints. Não apague — sobrescrever o `sprint-wip.md` antes do próximo `/sprint-start` é seguro porque o contexto vive no arquivo arquivado.
+O arquivo arquivado é a **fonte de contexto** que `/sprint-start` (STEP 1b) lê na próxima sexta para preservar "On my mind", "On hold" e metas de Health entre sprints. Não apague — sobrescrever o `sprint-wip.md` antes do próximo `/sprint-start` é seguro porque o contexto vive no arquivo arquivado.
 
 3. **Upload automático para o Google Doc:**
 

--- a/sprint-start.md
+++ b/sprint-start.md
@@ -4,7 +4,7 @@ Você é um assistente de revisão e planejamento semanal — **Etapa 1** (últi
 
 ---
 
-## PASSO 1: Período do sprint
+## STEP 1: Período do sprint
 
 Execute **sem pedir permissão**, substituindo `YYYY-MM-DD` pela data de hoje:
 
@@ -16,11 +16,11 @@ O JSON retornado contém dois objetos:
 - `current` — sprint atual: `start`, `end`, `workdays`, `holidays[]`
 - `next` — próximo sprint (mesma duração, feriados descontados): mesmos campos
 
-Use `current.*` no header do Sprint Review (PASSO 4a) e `next.*` no header do Sprint Planning (PASSO 4c). O header do Review aparece para o usuário validar — se o período estiver errado, ele corrige durante a revisão.
+Use `current.*` no header do Sprint Review (STEP 4a) e `next.*` no header do Sprint Planning (STEP 4c). O header do Review aparece para o usuário validar — se o período estiver errado, ele corrige durante a revisão.
 
 ---
 
-## PASSO 1b: Contexto do sprint anterior
+## STEP 1b: Contexto do sprint anterior
 
 Execute **sem pedir permissão**:
 
@@ -36,7 +36,7 @@ O retorno é `null` no primeiro uso (sem `.sprints/archive/` ou `sprint-final.md
 - `health_goals{}` — metas de Health anteriores (ex.: `{"Meditate":"7 days","Sleep Score":"82"}`)
 - `improvement_goals[]` — alvos de Improvement anteriores (ex.: `["Work +2h in important outputs", "Spend 1+ hours OoH", "Make impact"]`)
 
-Aplique `improvement_goals` e `health_goals` no PASSO 4b (avaliação do sprint que acabou) e `on_my_mind`, `on_hold`, `health_goals` no PASSO 4c (planejamento do próximo sprint). Itens só são removidos de `on_my_mind` / `on_hold` se houver sinal **explícito** nos dados do PASSO 2 — nunca por inferência genérica:
+Aplique `improvement_goals` e `health_goals` no STEP 4b (avaliação do sprint que acabou) e `on_my_mind`, `on_hold`, `health_goals` no STEP 4c (planejamento do próximo sprint). Itens só são removidos de `on_my_mind` / `on_hold` se houver sinal **explícito** nos dados do STEP 2 — nunca por inferência genérica:
 
 - Remover de **On my mind** se: tarefa concluída em TickTick OU email de decisão/aprovação em Gmail.
 - Mover de **On hold** para **Projects Priority** se: bloqueador respondeu por email/calendário OU tarefas reativadas em TickTick.
@@ -48,11 +48,11 @@ Aplique `improvement_goals` e `health_goals` no PASSO 4b (avaliação do sprint 
 node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts trends --repo <<REPO_PATH>>
 ```
 
-Retorna `sprints[]` (série ascendente: períodos, projetos, goals, results), `latest_carryover` (cada item de On my mind / On hold com `age` = nº de sprints consecutivos) e `projects[]` (cadência: `sprints`, `streak`, `lastSeen`). Aplique no PASSO 4b (contexto de tendência ao lado dos resultados) e no PASSO 4c (calibração de metas, envelhecimento de carryover, cadência de projeto).
+Retorna `sprints[]` (série ascendente: períodos, projetos, goals, results), `latest_carryover` (cada item de On my mind / On hold com `age` = nº de sprints consecutivos) e `projects[]` (cadência: `sprints`, `streak`, `lastSeen`). Aplique no STEP 4b (contexto de tendência ao lado dos resultados) e no STEP 4c (calibração de metas, envelhecimento de carryover, cadência de projeto).
 
 ---
 
-## PASSO 2: Coleta automática de dados
+## STEP 2: Coleta automática de dados
 
 Execute em paralelo **sem pedir permissão**:
 
@@ -60,7 +60,7 @@ Execute em paralelo **sem pedir permissão**:
 - `list_projects` (TickTick)
 - `gcal_list_calendars` (Google Calendar)
 
-**Lote B** (com IDs em mãos, período = `current.start` a `current.end` do PASSO 1):
+**Lote B** (com IDs em mãos, período = `current.start` a `current.end` do STEP 1):
 - `list_completed_tasks_by_date` (TickTick) — `current.start` até `current.end`
 - `list_undone_tasks_by_date` (TickTick) — tarefas abertas
 - `gcal_list_events` — `current.start` até `current.end`; depois filtre conforme abaixo
@@ -68,13 +68,13 @@ Execute em paralelo **sem pedir permissão**:
 - `gh api "/users/vjpixel/events?per_page=50"` (GitHub); depois filtre conforme abaixo
 - **Claude Code transcripts** — calcule `dayAfterEnd` = dia seguinte a `current.end` em formato `YYYY-MM-DD` (ex.: `current.end=2026-05-03` → `dayAfterEnd=2026-05-04`), então rode (substituindo as duas datas literalmente): `find ~/.claude/projects/ -maxdepth 2 -name "*.jsonl" -newermt 'current.start' ! -newermt 'dayAfterEnd'`. Para cada arquivo top-level, extraia: primeira mensagem do usuário (objetivo), última mensagem do assistente (resultado), PRs/issues referenciados. **Delegue a um subagente Explore** para não poluir o contexto principal.
 
-**Filtro obrigatório.** Após CADA chamada MCP (`gcal_list_events`, `gmail_search_messages`, `gh api events`), passe o resultado pelo subcomando correspondente ANTES de qualquer outro uso — inclusive contagem, sumarização ou exibição parcial. Bypass do filtro (ex.: parsear o JSON diretamente em Node one-liner) reintroduz os bugs que o filtro foi criado para evitar.
+**Filtro obrigatório.** Após CADA chamada MCP (`gcal_list_events`, `gmail_search_messages`, `gh api events`), passe o resultado pelo subcomando correspondente ANTES de qualquer outro uso — inclusive contagem, sumarização ou exibição parcial. Para `gcal_list_events`, calcule primeiro `myResponseStatus` em cada evento (`responseStatus` do attendee com `self: true`; sem `attendees` → trate como `"accepted"`) — é esse campo que `filter-gcal` usa para descartar convites ainda não respondidos. Bypass do filtro (ex.: parsear o JSON diretamente em Node one-liner) reintroduz os bugs que o filtro foi criado para evitar.
 
 Passe o JSON via heredoc (evita quoting issues com aspas, backticks, `$`):
 
 ```bash
 node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal <<'JSON'
-{aqui-cola-o-JSON-do-MCP}
+{aqui-cola-o-JSON-do-MCP, cada evento já com myResponseStatus}
 JSON
 ```
 
@@ -82,7 +82,7 @@ Use `filter-gmail` (sem flags) e `filter-github --start current.start --end curr
 
 ---
 
-## PASSO 3: Plano do dia
+## STEP 3: Plano do dia
 
 Com os dados coletados, gere o **plano do dia** (hoje):
 
@@ -111,7 +111,7 @@ Baseie os blocos no horário atual e no que o usuário costuma fazer (se tiver c
 
 ---
 
-## PASSO 4a: Sprint Review
+## STEP 4a: Sprint Review
 
 Gere e exiba **apenas o Sprint Review**. Marque campos incompletos com `[PENDING]`.
 
@@ -192,9 +192,9 @@ Aguarde confirmação antes de continuar.
 
 ---
 
-## PASSO 4b: Sprint Retrospective
+## STEP 4b: Sprint Retrospective
 
-Após confirmação do Review, gere e exiba **apenas o Sprint Retrospective**. All generated content must be in English (see PASSO 4a for the full rule).
+Após confirmação do Review, gere e exiba **apenas o Sprint Retrospective**. All generated content must be in English (see STEP 4a for the full rule).
 
 ```
 ## Sprint Retrospective *([período], X workdays)*
@@ -228,12 +228,12 @@ Após confirmação do Review, gere e exiba **apenas o Sprint Retrospective**. A
 * [1 bullet — action item concreto e rastreável (próximo passo claro), não uma descrição]
 ```
 
-- **Tabelas vêm do archive** (PASSO 1b):
+- **Tabelas vêm do archive** (STEP 1b):
   - "Last week's improvement goals" → use as 3 linhas de `improvement_goals[]` exatamente como vieram. Não invente nem reuse labels fixos.
   - "Health goals" → use as chaves de `health_goals{}` exatamente como vieram, com a meta no denominador (ex.: `{"Meditate":"7 days"}` → linha `| Meditate | **[PENDING] / 7 days** |`).
   - Se o archive for `null` (primeiro uso) OU as listas vierem vazias, mantenha as 3 linhas placeholder com `[PENDING] / ?` e adicione nota: "(archive sem metas anteriores — preencher manualmente)".
 - Result column: marque com `[PENDING] / X` quando não conseguir derivar dos dados; o usuário preenche.
-- Se houver `trends` (PASSO 1b), anexe o contexto de tendência ao lado de cada resultado (ex.: `Meditate: 1 → 2 → 4`) — uma meta de improvement que recorre há vários sprints sem evolução é sinal para a seção "What could be improved?".
+- Se houver `trends` (STEP 1b), anexe o contexto de tendência ao lado de cada resultado (ex.: `Meditate: 1 → 2 → 4`) — uma meta de improvement que recorre há vários sprints sem evolução é sinal para a seção "What could be improved?".
 - Rascunhar as 3 seções narrativas agora — não deixar como [PENDING]
 - Cada seção narrativa tem exatamente 1 bullet
 - "What did I do well?" foca em melhorias no sistema de trabalho
@@ -247,9 +247,9 @@ Aguarde confirmação antes de continuar.
 
 ---
 
-## PASSO 4c: Sprint Planning
+## STEP 4c: Sprint Planning
 
-Após confirmação da Retro, gere e exiba **apenas o Sprint Planning**. All generated content must be in English (see PASSO 4a for the full rule).
+Após confirmação da Retro, gere e exiba **apenas o Sprint Planning**. All generated content must be in English (see STEP 4a for the full rule).
 
 ```
 ## Sprint Planning *([próximo período], X workdays)*
@@ -294,7 +294,7 @@ Após confirmação da Retro, gere e exiba **apenas o Sprint Planning**. All gen
 ```
 
 - Usar seção "Projects Priority" (não "Priority order")
-- **Improvements**: por default carregue `improvement_goals[]` do archive (mesmas labels da Retro do PASSO 4b — espelham o ciclo). Só sugira mudanças se o "What will I commit to improving?" da Retro propuser explicitamente uma nova meta — nesse caso, substitua a linha correspondente.
+- **Improvements**: por default carregue `improvement_goals[]` do archive (mesmas labels da Retro do STEP 4b — espelham o ciclo). Só sugira mudanças se o "What will I commit to improving?" da Retro propuser explicitamente uma nova meta — nesse caso, substitua a linha correspondente.
 - **Health goals**: por default carregue as mesmas chaves de `health_goals{}` do archive com as mesmas metas. Só ajuste se o Retrospective sinalizar que vale puxar a meta (ex.: Sleep Score atingido 3 sprints seguidos → propor +2). Sempre propor números concretos — nunca deixar [PENDING].
 - "On my mind" e "On hold": preservar os itens do sprint anterior se não houver indicação de mudança. Com `trends`, anexe a idade (ex.: "Job Hunt — 5 sprints"): item com `age ≥ 3` → propor escalar, mudar abordagem ou dropar, não apenas recarregar
 - Outcomes: propor um resultado concreto por projeto ativo — o que tornaria o sprint bem-sucedido para aquele projeto
@@ -314,7 +314,7 @@ Aguarde confirmação antes de continuar.
 
 ---
 
-## PASSO 4d: Tarefas focadas da semana
+## STEP 4d: Tarefas focadas da semana
 
 Com o Planning confirmado (Projects Priority + Outcomes), traduza isso num pequeno conjunto de tarefas concretas para a semana:
 
@@ -323,13 +323,13 @@ Com o Planning confirmado (Projects Priority + Outcomes), traduza isso num peque
 3. Não aplique um corte uniforme de "N tarefas" para todas as prioridades. Distinga dois casos:
    - **Outcome é "fechar uma checklist específica"** → liste **todas** as tarefas abertas que batem com aquele Outcome, mesmo que sejam muitas.
    - **Prioridade com backlog grande e aberto** → aplique o mesmo corte de "top 3 por prioridade" usado nos Outputs.
-4. Antes de propor a lista, verifique se algum item já foi concluído em sessões recentes mesmo que ainda apareça aberto no TickTick (cruze com o PASSO 2 — transcripts, emails, changelogs). Não presuma que "status aberto" = "ainda não feito".
+4. Antes de propor a lista, verifique se algum item já foi concluído em sessões recentes mesmo que ainda apareça aberto no TickTick (cruze com o STEP 2 — transcripts, emails, changelogs). Não presuma que "status aberto" = "ainda não feito".
 5. Proponha o conjunto resultante ao usuário para confirmar, ajustar ou rejeitar — no mesmo espírito de como o day-plan propõe o MIT diário.
 6. Registre o conjunto acordado numa seção "Focus tasks for the week" dentro do Sprint Planning, para o `/sprint-close` conferir depois.
 
 ---
 
-## PASSO 5: Salvar rascunho
+## STEP 5: Salvar rascunho
 
 Após confirmação do Planning, salve o documento completo (plano do dia + Review + Retro + Planning) no arquivo `<<REPO_PATH>>/.sprints/sprint-wip.md`.
 
@@ -361,13 +361,13 @@ on_hold: []
 ```
 
 Regras do frontmatter:
-- `improvement_goals`, `health_goals`, `on_my_mind`, `on_hold` = exatamente os valores da seção **Planning** (PASSO 4c) — viram o "archive" lido pelo próximo sprint.
+- `improvement_goals`, `health_goals`, `on_my_mind`, `on_hold` = exatamente os valores da seção **Planning** (STEP 4c) — viram o "archive" lido pelo próximo sprint.
 - Liste vazios como `[]` (nunca omita a chave). Listas em bloco (`- item`); `health_goals` é um mapa aninhado (`Chave: meta`).
 - O bloco `---…---` precede tudo (requisito do Obsidian); o comentário `sprint-wip` e o corpo do doc vêm depois.
 
 ---
 
-## PASSO 6: Confirmar
+## STEP 6: Confirmar
 
 Informe ao usuário:
 - "Rascunho salvo em `.sprints/sprint-wip.md`. Quando quiser fechar o sprint na segunda, use `/sprint-close`."


### PR DESCRIPTION
## Summary
- Merges day-plan's "Tarefas do dia" and "Tarefas atrasadas" steps into one (#90)
- Surfaces this week's Improvement + Health goals as the very first step of `/day-plan` (#92)
- Fixes the calendar RSVP filter: `filter-gcal` already drops events whose `myResponseStatus` isn't `accepted`, but nothing told the assistant to compute that field from the raw Google Calendar `attendees`/`self` shape before piping events through it — so not-yet-accepted invites were never actually excluded. Added that derivation step to day-plan, day-wrap, sprint-start, and sprint-close (#91)
- Renames all `PASSO` headers/cross-references to `STEP` across day-plan.md, day-wrap.md, sprint-start.md, sprint-close.md, README.md (#93)
- day-plan/day-wrap summaries now list the full day's tasks instead of just the top 3 (#94)

Closes #90, #91, #92, #93, #94

## Test plan
- [x] `npm test` — all 119 tests pass
- [x] `bash bin/check-skills.sh` — passes (no hardcoded paths, no re-embedded filter/date-math logic)
- [x] Manually re-numbered all in-file STEP cross-references and verified none were left stale
- [x] Confirmed `lib/archive.ts`'s "Plano do dia" stripping logic is untouched (only day-plan.md's own chat-facing summary heading changed to English; the embedded sprint-wip template in sprint-start.md is unaffected)