### PR TITLE
fix: meditation/medicine reminder, fixed lunch block, full task list in day-wrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Two optional daily commands sit alongside the weekly cadence above — neither w
 - Proposes a single main focus for the day, connected to the active sprint's Projects Priority
 
 **`/day-wrap`** — Run each evening
-- Reviews today's completed tasks, and checks in separately on today's Improvement and Health goals
+- Reviews today's completed and still-open tasks, and checks in separately on today's Improvement and Health goals
 - Triages anything left undone, and helps plan tomorrow's tasks and calendar
 - Appends a one-line entry to `day-log.md` (same data directory as `sprint-wip.md`) — a running log meant to make the next `/sprint-start` reconstruction lighter
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The process runs in two stages:
 Two optional daily commands sit alongside the weekly cadence above — neither writes to the sprint document, both read from it:
 
 **`/day-plan`** — Run each morning
+- Opens with a quick, non-blocking meditation/medicine reminder
 - Clears the TickTick Inbox, lists today's tasks, surfaces overdue ones for triage
 - Pulls today's calendar and suggests time blocks around existing meetings
 - Proposes a single main focus for the day, connected to the active sprint's Projects Priority

--- a/day-plan.md
+++ b/day-plan.md
@@ -6,7 +6,7 @@ Você é um assistente de planejamento diário — roda toda manhã para organiz
 
 ## STEP 0: Meditação + remédio
 
-Antes de qualquer outra coisa, pergunte em 1 linha: "Meditate today? Take your medicine this morning?" e, na mesma resposta, já execute o STEP 1 em seguida — não espere a resposta do usuário chegar antes de continuar. É só um lembrete leve, não uma pergunta que exige resposta detalhada; se o usuário responder mais tarde, registre, mas não pare a execução dos próximos STEPs por causa disso.
+Antes de qualquer outra coisa, pergunte em 1 linha: "Meditate today? Take your medicine this morning?" e, na mesma resposta, já execute o STEP 1 em seguida — não espere a resposta do usuário chegar antes de continuar. É só um lembrete leve, não uma pergunta que exige resposta detalhada; não há log ou tabela onde a resposta seja gravada (o check-in de Health de verdade é à noite, no STEP 3 do `/day-wrap`) — se o usuário responder mais tarde, apenas reconheça, mas não pare a execução dos próximos STEPs por causa disso.
 
 ---
 
@@ -72,7 +72,7 @@ JSON
 
 Mostre os eventos confirmados de hoje. Com as tarefas do STEP 3 (já ajustadas) e os horários livres entre eventos, sugira blocos de tempo para as 1–3 tarefas mais importantes — sem sobrepor os eventos já confirmados. Pergunte se quer criar/ajustar esses blocos no calendário.
 
-**Almoço fixo.** Trate **12:30–14:00** como indisponível/almoço sempre — nunca proponha nem crie um bloco de tarefa dentro dessa janela, mesmo que o calendário mostre esse horário como livre.
+**Almoço fixo.** Trate **12:30–14:00** como indisponível/almoço sempre — nunca proponha nem crie um bloco de tarefa que sobreponha essa janela, mesmo parcialmente, mesmo que o calendário mostre esse horário como livre.
 
 Ao criar um bloco de calendário para uma task (não uma reunião real), use `colorId: "2"` (Sage/verde). **Não** use `colorId: "10"` (Basil) — já foi tentado antes e rejeitado.
 

--- a/day-plan.md
+++ b/day-plan.md
@@ -6,7 +6,7 @@ Você é um assistente de planejamento diário — roda toda manhã para organiz
 
 ## STEP 0: Meditação + remédio
 
-Antes de qualquer outra coisa, pergunte rapidamente (1 linha, sem bloquear o fluxo se a resposta demorar): "Meditate today? Take your medicine this morning?" — é só um lembrete leve, não uma pergunta que exige resposta detalhada. Registre a resposta se o usuário der uma, mas siga para o STEP 1 independente disso.
+Antes de qualquer outra coisa, pergunte em 1 linha: "Meditate today? Take your medicine this morning?" e, na mesma resposta, já execute o STEP 1 em seguida — não espere a resposta do usuário chegar antes de continuar. É só um lembrete leve, não uma pergunta que exige resposta detalhada; se o usuário responder mais tarde, registre, mas não pare a execução dos próximos STEPs por causa disso.
 
 ---
 

--- a/day-plan.md
+++ b/day-plan.md
@@ -4,6 +4,12 @@ Você é um assistente de planejamento diário — roda toda manhã para organiz
 
 ---
 
+## STEP 0: Meditação + remédio
+
+Antes de qualquer outra coisa, pergunte rapidamente (1 linha, sem bloquear o fluxo se a resposta demorar): "Meditate today? Take your medicine this morning?" — é só um lembrete leve, não uma pergunta que exige resposta detalhada. Registre a resposta se o usuário der uma, mas siga para o STEP 1 independente disso.
+
+---
+
 ## STEP 1: Metas do sprint
 
 Execute **sem pedir permissão**:
@@ -65,6 +71,8 @@ JSON
 ```
 
 Mostre os eventos confirmados de hoje. Com as tarefas do STEP 3 (já ajustadas) e os horários livres entre eventos, sugira blocos de tempo para as 1–3 tarefas mais importantes — sem sobrepor os eventos já confirmados. Pergunte se quer criar/ajustar esses blocos no calendário.
+
+**Almoço fixo.** Trate **12:30–14:00** como indisponível/almoço sempre — nunca proponha nem crie um bloco de tarefa dentro dessa janela, mesmo que o calendário mostre esse horário como livre.
 
 Ao criar um bloco de calendário para uma task (não uma reunião real), use `colorId: "2"` (Sage/verde). **Não** use `colorId: "10"` (Basil) — já foi tentado antes e rejeitado.
 

--- a/day-wrap.md
+++ b/day-wrap.md
@@ -4,12 +4,15 @@ Você é um assistente de wrap diário — roda toda noite para fechar o dia.
 
 ---
 
-## STEP 1: Tarefas concluídas hoje
+## STEP 1: Tarefas de hoje
 
 Execute **sem pedir permissão**:
 - `list_completed_tasks_by_date` (TickTick) — hoje
+- `list_undone_tasks_by_time_query` (TickTick) — hoje
 
-Mostre a lista. Pergunte: "Bateu tudo que estava planejado? Algo mais que você fez e não está no TickTick?" — adicione e marque como concluído qualquer item mencionado que não apareça na lista.
+Mostre a lista combinada — concluídas e ainda em aberto — antes de perguntar. Pergunte: "Bateu tudo que estava planejado? Algo mais que você fez e não está no TickTick?" — adicione e marque como concluído qualquer item mencionado que não apareça na lista.
+
+As tarefas ainda em aberto ficam só para visualização aqui; a decisão de empurrar/reagendar/abandonar cada uma acontece no STEP 4.
 
 ---
 
@@ -62,6 +65,8 @@ JSON
 ```
 
 Mostre os eventos confirmados de amanhã. Ajude a encaixar as tarefas do STEP 5 nos horários livres — pergunte se quer criar/ajustar blocos.
+
+**Almoço fixo.** Trate **12:30–14:00** como indisponível/almoço sempre — nunca proponha nem crie um bloco de tarefa dentro dessa janela, mesmo que o calendário mostre esse horário como livre.
 
 Ao criar um bloco de calendário para uma task (não uma reunião real), use `colorId: "2"` (Sage/verde). **Não** use `colorId: "10"` (Basil) — já foi tentado antes e rejeitado.
 

--- a/day-wrap.md
+++ b/day-wrap.md
@@ -10,7 +10,7 @@ Execute **sem pedir permissão**:
 - `list_completed_tasks_by_date` (TickTick) — hoje
 - `list_undone_tasks_by_time_query` (TickTick) — hoje
 
-Mostre a lista combinada — concluídas e ainda em aberto — antes de perguntar. Pergunte: "Bateu tudo que estava planejado? Algo mais que você fez e não está no TickTick?" — adicione e marque como concluído qualquer item mencionado que não apareça na lista.
+Mostre a lista combinada — concluídas e ainda em aberto, marcando claramente quais estão em aberto — antes de perguntar. Pergunte: "Bateu tudo que estava planejado? Algo mais que você fez e não está no TickTick?" — adicione e marque como concluído qualquer item mencionado que não apareça na lista.
 
 As tarefas ainda em aberto ficam só para visualização aqui; a decisão de empurrar/reagendar/abandonar cada uma acontece no STEP 4.
 
@@ -66,7 +66,7 @@ JSON
 
 Mostre os eventos confirmados de amanhã. Ajude a encaixar as tarefas do STEP 5 nos horários livres — pergunte se quer criar/ajustar blocos.
 
-**Almoço fixo.** Trate **12:30–14:00** como indisponível/almoço sempre — nunca proponha nem crie um bloco de tarefa dentro dessa janela, mesmo que o calendário mostre esse horário como livre.
+**Almoço fixo.** Trate **12:30–14:00** como indisponível/almoço sempre — nunca proponha nem crie um bloco de tarefa que sobreponha essa janela, mesmo parcialmente, mesmo que o calendário mostre esse horário como livre.
 
 Ao criar um bloco de calendário para uma task (não uma reunião real), use `colorId: "2"` (Sage/verde). **Não** use `colorId: "10"` (Basil) — já foi tentado antes e rejeitado.
 

--- a/day-wrap.md
+++ b/day-wrap.md
@@ -36,7 +36,7 @@ Do mesmo `content` (não rode `read-wip` de novo), leia o bloco `health_goals:`.
 
 ## STEP 4: Triagem das tarefas não concluídas
 
-Compare as tarefas planejadas de hoje (do `/day-plan` da manhã, se houver, ou `list_undone_tasks_by_time_query` de hoje) com as concluídas do STEP 1. Para cada tarefa que sobrou, pergunte: empurrar para amanhã, reagendar para outro dia, ou abandonar. Aplique via `update_task` (`status: -1` para abandonar).
+Use a lista de tarefas em aberto já obtida no STEP 1 (não chame `list_undone_tasks_by_time_query` de novo) — ou, se houver, o `/day-plan` da manhã. Para cada tarefa que sobrou, pergunte: empurrar para amanhã, reagendar para outro dia, ou abandonar. Aplique via `update_task` (`status: -1` para abandonar).
 
 ---
 

--- a/sprint-start.md
+++ b/sprint-start.md
@@ -107,7 +107,7 @@ Blocos de tempo sugeridos:
 [HH:MM]–[HH:MM]  [bloco 3 se necessário]
 ```
 
-Baseie os blocos no horário atual e no que o usuário costuma fazer (se tiver contexto de sprints anteriores). Trate **12:30–14:00** como indisponível/almoço sempre — nunca proponha um bloco dentro dessa janela.
+Baseie os blocos no horário atual e no que o usuário costuma fazer (se tiver contexto de sprints anteriores). Trate **12:30–14:00** como indisponível/almoço sempre — nunca proponha um bloco que sobreponha essa janela, mesmo parcialmente.
 
 ---
 

--- a/sprint-start.md
+++ b/sprint-start.md
@@ -107,7 +107,7 @@ Blocos de tempo sugeridos:
 [HH:MM]–[HH:MM]  [bloco 3 se necessário]
 ```
 
-Baseie os blocos no horário atual e no que o usuário costuma fazer (se tiver contexto de sprints anteriores).
+Baseie os blocos no horário atual e no que o usuário costuma fazer (se tiver contexto de sprints anteriores). Trate **12:30–14:00** como indisponível/almoço sempre — nunca proponha um bloco dentro dessa janela.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add a lightweight, non-blocking meditation/medicine reminder at the start of day-plan (STEP 0)
- Treat 12:30-14:00 as a fixed lunch break when suggesting/creating calendar time-blocks, in day-plan, day-wrap, and sprint-start
- day-wrap STEP 1 now shows today's completed AND still-open tasks (not just completed), reusing that list in STEP 4 instead of re-fetching it

Closes #96, #97, #98.

## Test plan
- [ ] Run `/day-plan` tomorrow morning and confirm STEP 0 asks the meditation/medicine question without blocking progress to STEP 1
- [ ] Run `/day-plan` or `/day-wrap` with a free 12:30-14:00 slot on the calendar and confirm no task block gets suggested inside it
- [ ] Run `/day-wrap` and confirm STEP 1 shows both completed and open tasks for today, and STEP 4 doesn't re-fetch the open list

🤖 Generated with [Claude Code](https://claude.com/claude-code)