### PR TITLE
fix: gcal auto myResponseStatus, priority-ordered day-plan, hardened English rule

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -245,6 +245,18 @@ test('cli: filter-github rejects missing --end flag', () => {
   assert.match(r.stderr, /--end requires YYYY-MM-DD/);
 });
 
+test('cli: filter-gcal derives myResponseStatus from raw attendees, no precompute needed', () => {
+  const events = [
+    { id: 'a', summary: 'Standup', attendees: [{ email: 'me@x.com', self: true, responseStatus: 'accepted' }] },
+    { id: 'b', summary: 'Skip me', attendees: [{ email: 'me@x.com', self: true, responseStatus: 'declined' }] },
+    { id: 'c', summary: 'Self-created, no attendees' },
+  ];
+  const r = run(['filter-gcal'], { input: JSON.stringify(events) });
+  assert.equal(r.status, 0, r.stderr);
+  const out = JSON.parse(r.stdout);
+  assert.deepEqual(out.map((e: { id: string }) => e.id), ['a', 'c']);
+});
+
 test('cli: filter-gcal rejects non-array stdin with clear error', () => {
   const r = run(['filter-gcal'], { input: '{"not":"array"}' });
   assert.equal(r.status, 1);

--- a/__tests__/filters.test.ts
+++ b/__tests__/filters.test.ts
@@ -1,6 +1,36 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { filterAcceptedCalendarEvents, filterRelevantEmails, windowGithubEvents } from '../lib/filters.js';
+import { filterAcceptedCalendarEvents, filterRelevantEmails, windowGithubEvents, withMyResponseStatus } from '../lib/filters.js';
+
+// withMyResponseStatus
+
+test('withMyResponseStatus: derives from attendees[].self', () => {
+  const events = [
+    { id: '1', attendees: [{ email: 'me@x.com', self: true, responseStatus: 'accepted' }, { email: 'other@x.com' }] },
+    { id: '2', attendees: [{ email: 'me@x.com', self: true, responseStatus: 'declined' }] },
+  ];
+  const result = withMyResponseStatus(events);
+  assert.equal(result[0].myResponseStatus, 'accepted');
+  assert.equal(result[1].myResponseStatus, 'declined');
+});
+
+test('withMyResponseStatus: treats self-created events with no attendees as accepted', () => {
+  const events = [{ id: '1' }];
+  const result = withMyResponseStatus(events);
+  assert.equal(result[0].myResponseStatus, 'accepted');
+});
+
+test('withMyResponseStatus: defaults to needsAction when self is not found in attendees', () => {
+  const events = [{ id: '1', attendees: [{ email: 'other@x.com', responseStatus: 'accepted' }] }];
+  const result = withMyResponseStatus(events);
+  assert.equal(result[0].myResponseStatus, 'needsAction');
+});
+
+test('withMyResponseStatus: leaves a precomputed myResponseStatus untouched', () => {
+  const events = [{ id: '1', myResponseStatus: 'tentative', attendees: [{ self: true, responseStatus: 'accepted' }] }];
+  const result = withMyResponseStatus(events);
+  assert.equal(result[0].myResponseStatus, 'tentative');
+});
 
 // filterAcceptedCalendarEvents
 

--- a/__tests__/filters.test.ts
+++ b/__tests__/filters.test.ts
@@ -20,6 +20,12 @@ test('withMyResponseStatus: treats self-created events with no attendees as acce
   assert.equal(result[0].myResponseStatus, 'accepted');
 });
 
+test('withMyResponseStatus: treats an empty attendees array the same as no attendees (accepted)', () => {
+  const events = [{ id: '1', attendees: [] }];
+  const result = withMyResponseStatus(events);
+  assert.equal(result[0].myResponseStatus, 'accepted');
+});
+
 test('withMyResponseStatus: defaults to needsAction when self is not found in attendees', () => {
   const events = [{ id: '1', attendees: [{ email: 'other@x.com', responseStatus: 'accepted' }] }];
   const result = withMyResponseStatus(events);
@@ -52,7 +58,7 @@ test('filterAcceptedCalendarEvents: returns empty for no accepted', () => {
   assert.equal(filterAcceptedCalendarEvents(events).length, 0);
 });
 
-test('filterAcceptedCalendarEvents: drops events with missing status', () => {
+test('filterAcceptedCalendarEvents: drops events with no myResponseStatus (unit-level; the filter-gcal CLI derives it first via withMyResponseStatus)', () => {
   const events = [{ id: '1' }, { id: '2', myResponseStatus: 'accepted' }];
   const result = filterAcceptedCalendarEvents(events);
   assert.equal(result.length, 1);

--- a/bin/sprint.ts
+++ b/bin/sprint.ts
@@ -5,7 +5,7 @@ import { inferCurrentPeriod, nextPeriod } from '../lib/period.js';
 import { loadLatestArchive } from '../lib/archive.js';
 import { computeTrends } from '../lib/trends.js';
 import { readWip, archiveWip } from '../lib/wip.js';
-import { filterAcceptedCalendarEvents, filterRelevantEmails, windowGithubEvents } from '../lib/filters.js';
+import { filterAcceptedCalendarEvents, filterRelevantEmails, windowGithubEvents, withMyResponseStatus } from '../lib/filters.js';
 import { appendDayLog } from '../lib/daylog.js';
 
 const [, , subcommand, ...args] = process.argv;
@@ -124,7 +124,7 @@ async function main(): Promise<void> {
     }
 
     case 'filter-gcal': {
-      out(filterAcceptedCalendarEvents(parseStdinArray(await readStdin())));
+      out(filterAcceptedCalendarEvents(withMyResponseStatus(parseStdinArray(await readStdin()))));
       break;
     }
 

--- a/day-plan.md
+++ b/day-plan.md
@@ -1,16 +1,20 @@
-Você é um assistente de planejamento diário — roda toda manhã para organizar o dia.
+## Language
 
 **IMPORTANT:** Estas instruções estão em português apenas para quem as edita — responda ao usuário **sempre em inglês**, mesmo que ele escreva em português. Ao persistir texto redigido pelo assistente (day-log, sprint-wip), traduza para inglês antes de gravar; não persista texto em português. Exceção: títulos de tasks no TickTick — preserve exatamente como o usuário digitou, não traduza.
 
 ---
 
-## STEP 0: Meditação + remédio
-
-Antes de qualquer outra coisa, pergunte em 1 linha: "Meditate today? Take your medicine this morning?" e, na mesma resposta, já execute o STEP 1 em seguida — não espere a resposta do usuário chegar antes de continuar. É só um lembrete leve, não uma pergunta que exige resposta detalhada; não há log ou tabela onde a resposta seja gravada (o check-in de Health de verdade é à noite, no STEP 3 do `/day-wrap`) — se o usuário responder mais tarde, apenas reconheça, mas não pare a execução dos próximos STEPs por causa disso.
+Você é um assistente de planejamento diário — roda toda manhã para organizar o dia.
 
 ---
 
-## STEP 1: Metas do sprint
+## STEP 0: Meditação + remédio
+
+Antes de qualquer outra coisa — e lembrando que toda resposta a partir daqui deve ser em inglês, nunca em português — pergunte em 1 linha: "Meditate today? Take your medicine this morning?" e, na mesma resposta, já execute o STEP 1 em seguida — não espere a resposta do usuário chegar antes de continuar. É só um lembrete leve, não uma pergunta que exige resposta detalhada; não há log ou tabela onde a resposta seja gravada (o check-in de Health de verdade é à noite, no STEP 3 do `/day-wrap`) — se o usuário responder mais tarde, apenas reconheça, mas não pare a execução dos próximos STEPs por causa disso.
+
+---
+
+## STEP 1: Metas e prioridades do sprint
 
 Execute **sem pedir permissão**:
 
@@ -18,14 +22,20 @@ Execute **sem pedir permissão**:
 node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts read-wip --repo <<REPO_PATH>>
 ```
 
-O retorno tem um campo `content` com o texto bruto do `sprint-wip.md` (frontmatter YAML + corpo). Extraia `improvement_goals` e `health_goals` do frontmatter e mostre como lembrete rápido — 1-2 linhas cada, sem re-derivar as tabelas completas do Sprint Planning:
+O retorno tem um campo `content` com o texto bruto do `sprint-wip.md` (frontmatter YAML + corpo). Extraia:
+- `improvement_goals` e `health_goals` do frontmatter.
+- `Projects Priority` e `On my mind` do corpo.
+
+Mostre tudo como lembrete rápido — 1-2 linhas cada, sem re-derivar as tabelas completas do Sprint Planning:
 
 ```
 Improvements this week: [improvement_goals[] resumidos em 1 linha]
 Health goals this week: [health_goals{} resumidos em 1 linha]
+Projects Priority: [ordem de Projects Priority, ex.: Health → Admin → Diar.ia]
+On my mind: [on_my_mind resumido em 1 linha]
 ```
 
-Guarde o `content` retornado — reutilize no STEP 5 (Contexto do sprint) para extrair `Projects Priority` e `On my mind`, sem chamar `read-wip` de novo.
+Guarde o `content` e, principalmente, a **ordem de Projects Priority** — ela é usada para ordenar a lista de tarefas no STEP 3, para preferir tarefas nos blocos de calendário no STEP 4, e para o agrupamento no STEP 6. Não chame `read-wip` de novo neste run.
 
 ---
 
@@ -51,7 +61,9 @@ Execute **sem pedir permissão**:
 
 Filtre as atrasadas dentro do segundo resultado (as que têm `dueDate` anterior a hoje).
 
-Liste juntas as tarefas de hoje e as atrasadas, marcando claramente quais são atrasadas. Para as tarefas de hoje, pergunte: "Quer ajustar algo? (adicionar, remover, repriorizar)" Para cada tarefa atrasada, pergunte: fazer hoje, reagendar (pedir nova data), ou abandonar (`update_task` com `status: -1`). Aplique os ajustes pedidos (`create_task` / `update_task` / `delete_task` conforme o caso).
+**Ordene pela prioridade do sprint (STEP 1).** Associe cada tarefa ao projeto/tag do TickTick a que pertence e mostre primeiro as tarefas ligadas ao projeto de maior prioridade, depois o segundo, e assim por diante — tarefas que não batem com nenhum item de Projects Priority vão por último, na ordem original. A correspondência projeto↔prioridade é best-effort por nome (ignore emoji/maiúsculas — ex.: "🩺Health" casa com "Health"); prioridades que são tags espalhadas entre projetos (ex.: "Admin") casam pela tag da tarefa, não pelo projeto.
+
+Liste juntas as tarefas de hoje e as atrasadas nessa ordem, marcando claramente quais são atrasadas. Para as tarefas de hoje, pergunte: "Quer ajustar algo? (adicionar, remover, repriorizar)" Para cada tarefa atrasada, pergunte: fazer hoje, reagendar (pedir nova data), ou abandonar (`update_task` com `status: -1`). Aplique os ajustes pedidos (`create_task` / `update_task` / `delete_task` conforme o caso).
 
 ---
 
@@ -60,17 +72,19 @@ Liste juntas as tarefas de hoje e as atrasadas, marcando claramente quais são a
 Execute **sem pedir permissão**:
 - `gcal_list_events` — hoje
 
-**Filtro obrigatório.** Antes de montar o JSON, calcule `myResponseStatus` em cada evento: use o `responseStatus` do attendee com `self: true`; se o evento não tiver `attendees` (sem convidados, criado pelo próprio usuário), trate como `"accepted"`. Passe o resultado por `filter-gcal` ANTES de qualquer outro uso — inclusive contagem, sumarização ou exibição parcial (o subcomando descarta eventos cujo `myResponseStatus` não seja `accepted` — convites ainda não respondidos não entram na lista). Bypass do filtro (ex.: parsear o JSON diretamente em Node one-liner) reintroduz os bugs que o filtro foi criado para evitar.
+**Filtro obrigatório.** Passe o array de eventos bruto do MCP por `filter-gcal` ANTES de qualquer outro uso — inclusive contagem, sumarização ou exibição parcial. O subcomando já deriva `myResponseStatus` internamente a partir de `attendees[].self` (sem `attendees` → trata como `"accepted"`) e descarta tudo que não seja `accepted` — convites ainda não respondidos não entram na lista. Não precompute o campo. Bypass do filtro (ex.: parsear o JSON diretamente em Node one-liner) reintroduz os bugs que o filtro foi criado para evitar.
 
 Passe o JSON via heredoc (evita quoting issues com aspas, backticks, `$`):
 
 ```bash
 node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal <<'JSON'
-{aqui-cola-o-JSON-do-MCP, cada evento já com myResponseStatus}
+{aqui-cola-o-array-de-eventos-do-MCP, sem processamento}
 JSON
 ```
 
-Mostre os eventos confirmados de hoje. Com as tarefas do STEP 3 (já ajustadas) e os horários livres entre eventos, sugira blocos de tempo para as 1–3 tarefas mais importantes — sem sobrepor os eventos já confirmados. Pergunte se quer criar/ajustar esses blocos no calendário.
+Se o heredoc falhar com `unexpected EOF` (comum no Windows/git-bash, geralmente por causa de finais de linha CRLF quebrando o delimitador), use o fallback: grave o JSON num arquivo com a tool Write e rode `node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal < arquivo.json`.
+
+Mostre os eventos confirmados de hoje. Com as tarefas do STEP 3 (já ajustadas, na ordem de prioridade) e os horários livres entre eventos, sugira blocos de tempo para as 1–3 tarefas mais importantes — em caso de empate de urgência, prefira a tarefa ligada ao projeto de maior prioridade do sprint (STEP 1) — sem sobrepor os eventos já confirmados. Pergunte se quer criar/ajustar esses blocos no calendário.
 
 **Almoço fixo.** Trate **12:30–14:00** como indisponível/almoço sempre — nunca proponha nem crie um bloco de tarefa que sobreponha essa janela, mesmo parcialmente, mesmo que o calendário mostre esse horário como livre.
 
@@ -78,27 +92,23 @@ Ao criar um bloco de calendário para uma task (não uma reunião real), use `co
 
 ---
 
-## STEP 5: Contexto do sprint
+## STEP 5: Foco principal (MIT)
 
-Use o `content` já obtido no STEP 1 (não chame `read-wip` de novo). Extraia `Projects Priority` e `On my mind` desse texto.
-
----
-
-## STEP 6: Foco principal (MIT)
-
-Com base nas tarefas (STEP 3-4) e na prioridade do sprint (STEP 5), proponha **1 resultado** que tornaria o dia um sucesso, mostrando como ele conecta com a prioridade #1 da semana — ou sinalize se nada do dia está empurrando essa prioridade. Pergunte se o usuário concorda ou quer trocar.
+Com base nas tarefas (STEP 3-4) e na prioridade do sprint (STEP 1), proponha **1 resultado** que tornaria o dia um sucesso, mostrando como ele conecta com a prioridade #1 da semana — ou sinalize se nada do dia está empurrando essa prioridade. Pergunte se o usuário concorda ou quer trocar.
 
 ---
 
-## STEP 7: Goal do dia + papel
+## STEP 6: Goal do dia + papel
 
-Se o foco do STEP 6 ainda não cobriu isso, pergunte: "Qual é a meta de hoje?"
+Antes de perguntar sobre o papel, exiba a lista de tarefas do dia (STEP 3, já ajustada) agrupada por projeto, na ordem de Projects Priority (STEP 1) — o nome do projeto como cabeçalho **sem numeração** (a ordem dos grupos já indica a prioridade; numerar grupo e tarefas juntos é ruído visual). As tarefas dentro de cada grupo podem ser numeradas ou em bullet.
+
+Se o foco do STEP 5 ainda não cobriu isso, pergunte: "Qual é a meta de hoje?"
 
 Depois pergunte: "Pode sincronizar o papel (offline) com essas tarefas agora?" — é só um lembrete, não há ação automatizada aqui.
 
 ---
 
-## STEP 8: Resumo
+## STEP 7: Resumo
 
 Exiba um resumo final, com a lista **completa** das tarefas do dia (STEP 3, já ajustadas) — não apenas as 3 principais:
 
@@ -106,7 +116,7 @@ Exiba um resumo final, com a lista **completa** das tarefas do dia (STEP 3, já 
 ## Day plan — [DATA]
 
 Main focus:
-→ [resultado do STEP 6]
+→ [resultado do STEP 5]
 
 Today's tasks:
 1. [tarefa]

--- a/day-plan.md
+++ b/day-plan.md
@@ -58,10 +58,11 @@ Se o Gmail tiver itens pendentes, liste-os e ajude a transformar cada um numa a�
 Execute **sem pedir permissão**:
 - `list_undone_tasks_by_time_query` (TickTick) — hoje
 - `list_undone_tasks_by_date` (TickTick) — últimos 14 dias até hoje (máximo permitido pela ferramenta)
+- `list_projects` (TickTick) — necessário para resolver o `project_id`/`projectId` de cada tarefa (as duas chamadas acima só retornam o ID) num nome legível, usado na ordenação abaixo
 
 Filtre as atrasadas dentro do segundo resultado (as que têm `dueDate` anterior a hoje).
 
-**Ordene pela prioridade do sprint (STEP 1).** Associe cada tarefa ao projeto/tag do TickTick a que pertence e mostre primeiro as tarefas ligadas ao projeto de maior prioridade, depois o segundo, e assim por diante — tarefas que não batem com nenhum item de Projects Priority vão por último, na ordem original. A correspondência projeto↔prioridade é best-effort por nome (ignore emoji/maiúsculas — ex.: "🩺Health" casa com "Health"); prioridades que são tags espalhadas entre projetos (ex.: "Admin") casam pela tag da tarefa, não pelo projeto.
+**Ordene pela prioridade do sprint (STEP 1).** Associe cada tarefa ao projeto/tag do TickTick a que pertence (usando o nome resolvido via `list_projects`) e mostre primeiro as tarefas ligadas ao projeto de maior prioridade, depois o segundo, e assim por diante — tarefas que não batem com nenhum item de Projects Priority vão por último, na ordem original. A correspondência projeto↔prioridade é best-effort por nome (ignore emoji/maiúsculas — ex.: "🩺Health" casa com "Health"); prioridades que são tags espalhadas entre projetos (ex.: "Admin") casam pela tag da tarefa, não pelo projeto.
 
 Liste juntas as tarefas de hoje e as atrasadas nessa ordem, marcando claramente quais são atrasadas. Para as tarefas de hoje, pergunte: "Quer ajustar algo? (adicionar, remover, repriorizar)" Para cada tarefa atrasada, pergunte: fazer hoje, reagendar (pedir nova data), ou abandonar (`update_task` com `status: -1`). Aplique os ajustes pedidos (`create_task` / `update_task` / `delete_task` conforme o caso).
 

--- a/day-wrap.md
+++ b/day-wrap.md
@@ -1,6 +1,10 @@
-Você é um assistente de wrap diário — roda toda noite para fechar o dia.
+## Language
 
 **IMPORTANT:** Estas instruções estão em português apenas para quem as edita — responda ao usuário **sempre em inglês**, mesmo que ele escreva em português. Ao persistir texto redigido pelo assistente (day-log, sprint-wip), traduza para inglês antes de gravar; não persista texto em português. Exceção: títulos de tasks no TickTick — preserve exatamente como o usuário digitou, não traduza.
+
+---
+
+Você é um assistente de wrap diário — roda toda noite para fechar o dia.
 
 ---
 
@@ -54,15 +58,17 @@ Mostre a lista. Pergunte: "Quer incluir ou excluir algo?" Aplique os ajustes.
 Execute **sem pedir permissão**:
 - `gcal_list_events` — amanhã
 
-**Filtro obrigatório.** Antes de montar o JSON, calcule `myResponseStatus` em cada evento: use o `responseStatus` do attendee com `self: true`; se o evento não tiver `attendees` (sem convidados, criado pelo próprio usuário), trate como `"accepted"`. Passe o resultado por `filter-gcal` ANTES de qualquer outro uso — inclusive contagem, sumarização ou exibição parcial (o subcomando descarta eventos cujo `myResponseStatus` não seja `accepted` — convites ainda não respondidos não entram na lista). Bypass do filtro (ex.: parsear o JSON diretamente em Node one-liner) reintroduz os bugs que o filtro foi criado para evitar.
+**Filtro obrigatório.** Passe o array de eventos bruto do MCP por `filter-gcal` ANTES de qualquer outro uso — inclusive contagem, sumarização ou exibição parcial. O subcomando já deriva `myResponseStatus` internamente a partir de `attendees[].self` (sem `attendees` → trata como `"accepted"`) e descarta tudo que não seja `accepted` — convites ainda não respondidos não entram na lista. Não precompute o campo. Bypass do filtro (ex.: parsear o JSON diretamente em Node one-liner) reintroduz os bugs que o filtro foi criado para evitar.
 
 Passe o JSON via heredoc (evita quoting issues com aspas, backticks, `$`):
 
 ```bash
 node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal <<'JSON'
-{aqui-cola-o-JSON-do-MCP, cada evento já com myResponseStatus}
+{aqui-cola-o-array-de-eventos-do-MCP, sem processamento}
 JSON
 ```
+
+Se o heredoc falhar com `unexpected EOF` (comum no Windows/git-bash, geralmente por causa de finais de linha CRLF quebrando o delimitador), use o fallback: grave o JSON num arquivo com a tool Write e rode `node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal < arquivo.json`.
 
 Mostre os eventos confirmados de amanhã. Ajude a encaixar as tarefas do STEP 5 nos horários livres — pergunte se quer criar/ajustar blocos.
 

--- a/lib/filters.ts
+++ b/lib/filters.ts
@@ -16,7 +16,7 @@ export function withMyResponseStatus<T extends Record<string, unknown>>(events: 
   return events.map(e => {
     if (typeof e['myResponseStatus'] === 'string') return e;
     const attendees = e['attendees'];
-    if (Array.isArray(attendees)) {
+    if (Array.isArray(attendees) && attendees.length > 0) {
       const self = (attendees as Record<string, unknown>[]).find(a => a && a['self'] === true);
       return { ...e, myResponseStatus: (self?.['responseStatus'] as string) ?? 'needsAction' };
     }

--- a/lib/filters.ts
+++ b/lib/filters.ts
@@ -12,6 +12,18 @@ function isAmazon(from = '', subject = ''): boolean {
   return AMAZON_PATTERNS.some(p => p.test(from) || p.test(subject));
 }
 
+export function withMyResponseStatus<T extends Record<string, unknown>>(events: T[]): T[] {
+  return events.map(e => {
+    if (typeof e['myResponseStatus'] === 'string') return e;
+    const attendees = e['attendees'];
+    if (Array.isArray(attendees)) {
+      const self = (attendees as Record<string, unknown>[]).find(a => a && a['self'] === true);
+      return { ...e, myResponseStatus: (self?.['responseStatus'] as string) ?? 'needsAction' };
+    }
+    return { ...e, myResponseStatus: 'accepted' };
+  });
+}
+
 export function filterAcceptedCalendarEvents<T extends Record<string, unknown>>(events: T[]): T[] {
   return events.filter(e => e['myResponseStatus'] === 'accepted');
 }

--- a/sprint-close.md
+++ b/sprint-close.md
@@ -1,6 +1,10 @@
-Você é um assistente de revisão e planejamento semanal — **Etapa 2** (primeiro dia útil da semana nova).
+## Language
 
 **IMPORTANT:** Estas instruções estão em português apenas para quem as edita — responda ao usuário **sempre em inglês**, mesmo que ele escreva em português. Ao persistir texto (sprint-wip, day-log), traduza para inglês antes de gravar; não persista texto em português.
+
+---
+
+Você é um assistente de revisão e planejamento semanal — **Etapa 2** (primeiro dia útil da semana nova).
 
 ---
 
@@ -25,15 +29,17 @@ Execute em paralelo **sem pedir permissão** (período = `generated_at` do rascu
 - `gmail_search_messages` — mesmo período
 - **Claude Code transcripts** — `find ~/.claude/projects/ -maxdepth 2 -name "*.jsonl" -newermt 'generated_at'` (substitua a data literalmente em formato `YYYY-MM-DD`). Por sessão, extraia: objetivo, resultado, PRs/issues referenciados. **Delegue a um subagente Explore.**
 
-**Filtro obrigatório.** Após cada chamada MCP (`gcal_list_events`, `gmail_search_messages`), passe o resultado pelo subcomando correspondente ANTES de qualquer outro uso. Para `gcal_list_events`, calcule primeiro `myResponseStatus` em cada evento (`responseStatus` do attendee com `self: true`; sem `attendees` → trate como `"accepted"`) — é esse campo que `filter-gcal` usa para descartar convites ainda não respondidos. Bypass do filtro reintroduz os bugs que ele foi criado para evitar.
+**Filtro obrigatório.** Após cada chamada MCP (`gcal_list_events`, `gmail_search_messages`), passe o resultado bruto pelo subcomando correspondente ANTES de qualquer outro uso. Para `gcal_list_events`, não precompute nada — `filter-gcal` já deriva `myResponseStatus` internamente a partir de `attendees[].self` (sem `attendees` → trata como `"accepted"`) e descarta o que não for `accepted`. Bypass do filtro reintroduz os bugs que ele foi criado para evitar.
 
 Para os filtros, passe o JSON via heredoc:
 
 ```bash
 node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal <<'JSON'
-{aqui-cola-o-JSON-do-MCP, cada evento já com myResponseStatus}
+{aqui-cola-o-array-de-eventos-do-MCP, sem processamento}
 JSON
 ```
+
+Se o heredoc falhar com `unexpected EOF` (comum no Windows/git-bash, geralmente por causa de finais de linha CRLF quebrando o delimitador), use o fallback: grave o JSON num arquivo com a tool Write e rode `node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal < arquivo.json`.
 
 Use `filter-gmail` da mesma forma. Cada comando lê do stdin e retorna o array filtrado em stdout.
 

--- a/sprint-start.md
+++ b/sprint-start.md
@@ -1,6 +1,10 @@
-Você é um assistente de revisão e planejamento semanal — **Etapa 1** (último dia útil da semana).
+## Language
 
 **IMPORTANT:** Estas instruções estão em português apenas para quem as edita — responda ao usuário **sempre em inglês**, mesmo que ele escreva em português. Ao persistir texto (sprint-wip, day-log), traduza para inglês antes de gravar; não persista texto em português.
+
+---
+
+Você é um assistente de revisão e planejamento semanal — **Etapa 1** (último dia útil da semana).
 
 ---
 
@@ -68,15 +72,17 @@ Execute em paralelo **sem pedir permissão**:
 - `gh api "/users/vjpixel/events?per_page=50"` (GitHub); depois filtre conforme abaixo
 - **Claude Code transcripts** — calcule `dayAfterEnd` = dia seguinte a `current.end` em formato `YYYY-MM-DD` (ex.: `current.end=2026-05-03` → `dayAfterEnd=2026-05-04`), então rode (substituindo as duas datas literalmente): `find ~/.claude/projects/ -maxdepth 2 -name "*.jsonl" -newermt 'current.start' ! -newermt 'dayAfterEnd'`. Para cada arquivo top-level, extraia: primeira mensagem do usuário (objetivo), última mensagem do assistente (resultado), PRs/issues referenciados. **Delegue a um subagente Explore** para não poluir o contexto principal.
 
-**Filtro obrigatório.** Após CADA chamada MCP (`gcal_list_events`, `gmail_search_messages`, `gh api events`), passe o resultado pelo subcomando correspondente ANTES de qualquer outro uso — inclusive contagem, sumarização ou exibição parcial. Para `gcal_list_events`, calcule primeiro `myResponseStatus` em cada evento (`responseStatus` do attendee com `self: true`; sem `attendees` → trate como `"accepted"`) — é esse campo que `filter-gcal` usa para descartar convites ainda não respondidos. Bypass do filtro (ex.: parsear o JSON diretamente em Node one-liner) reintroduz os bugs que o filtro foi criado para evitar.
+**Filtro obrigatório.** Após CADA chamada MCP (`gcal_list_events`, `gmail_search_messages`, `gh api events`), passe o resultado bruto pelo subcomando correspondente ANTES de qualquer outro uso — inclusive contagem, sumarização ou exibição parcial. Para `gcal_list_events`, não precompute nada — `filter-gcal` já deriva `myResponseStatus` internamente a partir de `attendees[].self` (sem `attendees` → trata como `"accepted"`) e descarta o que não for `accepted`. Bypass do filtro (ex.: parsear o JSON diretamente em Node one-liner) reintroduz os bugs que o filtro foi criado para evitar.
 
 Passe o JSON via heredoc (evita quoting issues com aspas, backticks, `$`):
 
 ```bash
 node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal <<'JSON'
-{aqui-cola-o-JSON-do-MCP, cada evento já com myResponseStatus}
+{aqui-cola-o-array-de-eventos-do-MCP, sem processamento}
 JSON
 ```
+
+Se o heredoc falhar com `unexpected EOF` (comum no Windows/git-bash, geralmente por causa de finais de linha CRLF quebrando o delimitador), use o fallback: grave o JSON num arquivo com a tool Write e rode `node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal < arquivo.json`.
 
 Use `filter-gmail` (sem flags) e `filter-github --start current.start --end current.end` para os outros dois. Cada comando lê do stdin e retorna o array filtrado em stdout.
 


### PR DESCRIPTION
## Summary
- `filter-gcal` now derives `myResponseStatus` from `attendees[].self` internally instead of requiring callers to precompute it (closes #102)
- `day-plan.md`: sprint Projects Priority now loads at STEP 1, before tasks/calendar, and orders both plus the STEP 6 goal/role-sync task list (grouped by project, groups left unnumbered) (closes #100, #101)
- Windows/git-bash heredoc `unexpected EOF` failures (CRLF-related) now have a documented file-based fallback in all four skill files (closes #102)
- English-only output rule moved to a dedicated `## Language` section at the very top of day-plan/day-wrap/sprint-start/sprint-close, plus a duplicate reminder in day-plan's STEP 0 (closes #103)

## Test plan
- [x] `npm test` — 124/124 passing, including new coverage for `withMyResponseStatus` (unit + CLI end-to-end)
- [ ] Run a live `/day-plan` to confirm STEP 1 shows Projects Priority before tasks/calendar, STEP 3 orders tasks by priority, and STEP 6 groups by project without numbering groups