### PR TITLE
fix: --file flag for filter subcommands, deduplicate skill instruction blocks

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -257,6 +257,46 @@ test('cli: filter-gcal derives myResponseStatus from raw attendees, no precomput
   assert.deepEqual(out.map((e: { id: string }) => e.id), ['a', 'c']);
 });
 
+test('cli: filter-gcal --file reads JSON from a file instead of stdin (#105)', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 're-plan-cli-file-'));
+  const file = path.join(dir, 'events.json');
+  const events = [
+    { id: 'a', myResponseStatus: 'accepted', summary: 'Standup' },
+    { id: 'b', myResponseStatus: 'declined', summary: 'Skip me' },
+  ];
+  fs.writeFileSync(file, JSON.stringify(events));
+  const r = run(['filter-gcal', '--file', file]);
+  assert.equal(r.status, 0, r.stderr);
+  const out = JSON.parse(r.stdout);
+  assert.deepEqual(out.map((e: { id: string }) => e.id), ['a']);
+});
+
+test('cli: filter-gmail --file reads JSON from a file instead of stdin (#105)', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 're-plan-cli-file-'));
+  const file = path.join(dir, 'msgs.json');
+  const msgs = [
+    { from: 'noreply@amazon.com.br', subject: 'Pedido enviado' },
+    { from: 'recruiter@google.com', subject: 'Engineer role' },
+  ];
+  fs.writeFileSync(file, JSON.stringify(msgs));
+  const r = run(['filter-gmail', '--file', file]);
+  assert.equal(r.status, 0, r.stderr);
+  const out = JSON.parse(r.stdout);
+  assert.equal(out.length, 1);
+  assert.equal(out[0].from, 'recruiter@google.com');
+});
+
+test('cli: filter-github --file reads JSON from a file instead of stdin (#105)', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 're-plan-cli-file-'));
+  const file = path.join(dir, 'events.json');
+  const events = [{ id: 1, created_at: '2026-04-27T10:00:00Z' }, { id: 2, created_at: '2026-05-04T00:00:01Z' }];
+  fs.writeFileSync(file, JSON.stringify(events));
+  const r = run(['filter-github', '--start', '2026-04-27', '--end', '2026-05-03', '--file', file]);
+  assert.equal(r.status, 0, r.stderr);
+  const out = JSON.parse(r.stdout);
+  assert.deepEqual(out.map((e: { id: number }) => e.id), [1]);
+});
+
 test('cli: filter-gcal rejects non-array stdin with clear error', () => {
   const r = run(['filter-gcal'], { input: '{"not":"array"}' });
   assert.equal(r.status, 1);

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -36,6 +36,13 @@ function tmpRepo(): string {
   return dir;
 }
 
+function writeTempJson(basename: string, data: unknown): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 're-plan-cli-file-'));
+  const file = path.join(dir, basename);
+  fs.writeFileSync(file, JSON.stringify(data));
+  return file;
+}
+
 // ──────────────────────────── period ────────────────────────────
 
 test('cli: period --today returns current+next JSON to stdout', () => {
@@ -153,6 +160,17 @@ test('cli: append-day-log writes a dated line to day-log.md', () => {
   assert.equal(fs.readFileSync(dest, 'utf8'), '- [2026-06-30]: output: shipped X | blocker: none\n');
 });
 
+test('cli: append-day-log --file reads the line from a file instead of stdin (#105)', () => {
+  const repo = tmpRepo();
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 're-plan-cli-file-'));
+  const file = path.join(dir, 'line.txt');
+  fs.writeFileSync(file, 'output: shipped Y | blocker: none');
+  const r = run(['append-day-log', '--repo', repo, '--date', '2026-06-30', '--file', file]);
+  assert.equal(r.status, 0, r.stderr);
+  const dest = path.join(repo, '.sprints', 'day-log.md');
+  assert.equal(fs.readFileSync(dest, 'utf8'), '- [2026-06-30]: output: shipped Y | blocker: none\n');
+});
+
 test('cli: append-day-log rejects bad date format', () => {
   const repo = tmpRepo();
   const r = run(['append-day-log', '--repo', repo, '--date', '30/Jun'], { input: 'x' });
@@ -258,13 +276,10 @@ test('cli: filter-gcal derives myResponseStatus from raw attendees, no precomput
 });
 
 test('cli: filter-gcal --file reads JSON from a file instead of stdin (#105)', () => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 're-plan-cli-file-'));
-  const file = path.join(dir, 'events.json');
-  const events = [
+  const file = writeTempJson('events.json', [
     { id: 'a', myResponseStatus: 'accepted', summary: 'Standup' },
     { id: 'b', myResponseStatus: 'declined', summary: 'Skip me' },
-  ];
-  fs.writeFileSync(file, JSON.stringify(events));
+  ]);
   const r = run(['filter-gcal', '--file', file]);
   assert.equal(r.status, 0, r.stderr);
   const out = JSON.parse(r.stdout);
@@ -272,13 +287,10 @@ test('cli: filter-gcal --file reads JSON from a file instead of stdin (#105)', (
 });
 
 test('cli: filter-gmail --file reads JSON from a file instead of stdin (#105)', () => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 're-plan-cli-file-'));
-  const file = path.join(dir, 'msgs.json');
-  const msgs = [
+  const file = writeTempJson('msgs.json', [
     { from: 'noreply@amazon.com.br', subject: 'Pedido enviado' },
     { from: 'recruiter@google.com', subject: 'Engineer role' },
-  ];
-  fs.writeFileSync(file, JSON.stringify(msgs));
+  ]);
   const r = run(['filter-gmail', '--file', file]);
   assert.equal(r.status, 0, r.stderr);
   const out = JSON.parse(r.stdout);
@@ -287,14 +299,23 @@ test('cli: filter-gmail --file reads JSON from a file instead of stdin (#105)', 
 });
 
 test('cli: filter-github --file reads JSON from a file instead of stdin (#105)', () => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 're-plan-cli-file-'));
-  const file = path.join(dir, 'events.json');
-  const events = [{ id: 1, created_at: '2026-04-27T10:00:00Z' }, { id: 2, created_at: '2026-05-04T00:00:01Z' }];
-  fs.writeFileSync(file, JSON.stringify(events));
+  const file = writeTempJson('events.json', [
+    { id: 1, created_at: '2026-04-27T10:00:00Z' },
+    { id: 2, created_at: '2026-05-04T00:00:01Z' },
+  ]);
   const r = run(['filter-github', '--start', '2026-04-27', '--end', '2026-05-03', '--file', file]);
   assert.equal(r.status, 0, r.stderr);
   const out = JSON.parse(r.stdout);
   assert.deepEqual(out.map((e: { id: number }) => e.id), [1]);
+});
+
+test('cli: filter-gcal --file rejects a nonexistent path with a clean error, not a raw stack trace', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 're-plan-cli-file-'));
+  const missing = path.join(dir, 'does-not-exist.json');
+  const r = run(['filter-gcal', '--file', missing]);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /Could not read --file/);
+  assert.doesNotMatch(r.stderr, /at Object\.readFileSync/); // no raw Node stack trace
 });
 
 test('cli: filter-gcal rejects non-array stdin with clear error', () => {

--- a/__tests__/skill-consistency.test.ts
+++ b/__tests__/skill-consistency.test.ts
@@ -1,0 +1,38 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// day-plan.md, day-wrap.md, sprint-close.md, and sprint-start.md each hand-copy
+// the same "Language" rule and the same filter-gcal heredoc/--file usage block
+// (#106). Claude Code loads each skill .md standalone — there's no include
+// mechanism — so this test is the guardrail: it fails the build the moment a
+// skill file's copy drifts from shared/*.md, instead of drift going unnoticed
+// until someone reads all four files side by side.
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const SKILL_FILES = ['day-plan.md', 'day-wrap.md', 'sprint-close.md', 'sprint-start.md'];
+const SHARED_FRAGMENTS = ['language-block.md', 'filter-heredoc-block.md'];
+
+// Git's autocrlf can normalize .md files to CRLF on checkout independent of
+// how they were authored — that's a checkout detail, not real drift between
+// a skill file and its shared fragment, so line endings are normalized before
+// comparing.
+function normalizeNewlines(text: string): string {
+  return text.replace(/\r\n/g, '\n');
+}
+
+for (const fragment of SHARED_FRAGMENTS) {
+  const fragmentText = normalizeNewlines(fs.readFileSync(path.join(REPO_ROOT, 'shared', fragment), 'utf8')).trim();
+
+  for (const skillFile of SKILL_FILES) {
+    test(`skill consistency: ${skillFile} contains the exact shared/${fragment} block`, () => {
+      const skillText = normalizeNewlines(fs.readFileSync(path.join(REPO_ROOT, skillFile), 'utf8'));
+      assert.ok(
+        skillText.includes(fragmentText),
+        `${skillFile} does not contain the exact text of shared/${fragment} — ` +
+        `sync it (or update shared/${fragment} if the change is intentional and should apply everywhere)`
+      );
+    });
+  }
+}

--- a/bin/sprint.ts
+++ b/bin/sprint.ts
@@ -46,7 +46,13 @@ async function readStdin(): Promise<string> {
 // (and heredoc) entirely by writing the JSON to a file first (#105).
 async function readInput(args: string[]): Promise<string> {
   const filePath = flag(args, '--file');
-  return filePath ? fs.readFileSync(filePath, 'utf8') : readStdin();
+  if (!filePath) return readStdin();
+  try {
+    return fs.readFileSync(filePath, 'utf8');
+  } catch (e) {
+    process.stderr.write(`Could not read --file "${filePath}": ${(e as Error).message}\n`);
+    process.exit(1);
+  }
 }
 
 function parseStdinArray(raw: string): Record<string, unknown>[] {
@@ -123,7 +129,7 @@ async function main(): Promise<void> {
 
     case 'append-day-log': {
       const date = requireISODate('--date', flag(args, '--date'));
-      const line = (await readStdin()).trim();
+      const line = (await readInput(args)).trim();
       if (!line) {
         process.stderr.write('append-day-log requires a non-empty line on stdin\n');
         process.exit(1);

--- a/bin/sprint.ts
+++ b/bin/sprint.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import * as path from 'node:path';
+import * as fs from 'node:fs';
 import * as dotenv from 'dotenv';
 import { inferCurrentPeriod, nextPeriod } from '../lib/period.js';
 import { loadLatestArchive } from '../lib/archive.js';
@@ -38,6 +39,14 @@ async function readStdin(): Promise<string> {
     process.stdin.on('data', c => chunks.push(c));
     process.stdin.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
   });
+}
+
+// Windows/git-bash heredocs can fail with "unexpected EOF" when CRLF line
+// endings break the delimiter match. --file <path> lets callers skip stdin
+// (and heredoc) entirely by writing the JSON to a file first (#105).
+async function readInput(args: string[]): Promise<string> {
+  const filePath = flag(args, '--file');
+  return filePath ? fs.readFileSync(filePath, 'utf8') : readStdin();
 }
 
 function parseStdinArray(raw: string): Record<string, unknown>[] {
@@ -124,19 +133,19 @@ async function main(): Promise<void> {
     }
 
     case 'filter-gcal': {
-      out(filterAcceptedCalendarEvents(withMyResponseStatus(parseStdinArray(await readStdin()))));
+      out(filterAcceptedCalendarEvents(withMyResponseStatus(parseStdinArray(await readInput(args)))));
       break;
     }
 
     case 'filter-gmail': {
-      out(filterRelevantEmails(parseStdinArray(await readStdin())));
+      out(filterRelevantEmails(parseStdinArray(await readInput(args))));
       break;
     }
 
     case 'filter-github': {
       const start = requireISODate('--start', flag(args, '--start'));
       const end = requireISODate('--end', flag(args, '--end'));
-      out(windowGithubEvents(parseStdinArray(await readStdin()), start, end));
+      out(windowGithubEvents(parseStdinArray(await readInput(args)), start, end));
       break;
     }
 

--- a/day-plan.md
+++ b/day-plan.md
@@ -75,18 +75,18 @@ Execute **sem pedir permissão**:
 
 **Filtro obrigatório.** Passe o array de eventos bruto do MCP por `filter-gcal` ANTES de qualquer outro uso — inclusive contagem, sumarização ou exibição parcial. O subcomando já deriva `myResponseStatus` internamente a partir de `attendees[].self` (sem `attendees` → trata como `"accepted"`) e descarta tudo que não seja `accepted` — convites ainda não respondidos não entram na lista. Não precompute o campo. Bypass do filtro (ex.: parsear o JSON diretamente em Node one-liner) reintroduz os bugs que o filtro foi criado para evitar.
 
-Passe o JSON via heredoc (evita quoting issues com aspas, backticks, `$`):
+Grave o JSON num arquivo (tool Write) e passe via `--file` — mais confiável que heredoc no Windows/git-bash, onde heredocs podem falhar com `unexpected EOF` por causa de finais de linha CRLF quebrando o delimitador:
+
+```bash
+node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal --file arquivo.json
+```
+
+Alternativa (evita o arquivo intermediário, mas sujeita ao problema de CRLF acima): heredoc via stdin, com aspas simples no delimitador para evitar quoting issues com aspas, backticks, `$`:
 
 ```bash
 node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal <<'JSON'
 {aqui-cola-o-array-de-eventos-do-MCP, sem processamento}
 JSON
-```
-
-Alternativa mais confiável no Windows/git-bash — heredocs podem falhar com `unexpected EOF` por causa de finais de linha CRLF quebrando o delimitador: grave o JSON num arquivo (tool Write) e use `--file`, sem precisar de stdin/heredoc:
-
-```bash
-node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal --file arquivo.json
 ```
 
 Mostre os eventos confirmados de hoje. Com as tarefas do STEP 3 (já ajustadas, na ordem de prioridade) e os horários livres entre eventos, sugira blocos de tempo para as 1–3 tarefas mais importantes — em caso de empate de urgência, prefira a tarefa ligada ao projeto de maior prioridade do sprint (STEP 1) — sem sobrepor os eventos já confirmados. Pergunte se quer criar/ajustar esses blocos no calendário.

--- a/day-plan.md
+++ b/day-plan.md
@@ -83,7 +83,11 @@ node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal <<'JSON'
 JSON
 ```
 
-Se o heredoc falhar com `unexpected EOF` (comum no Windows/git-bash, geralmente por causa de finais de linha CRLF quebrando o delimitador), use o fallback: grave o JSON num arquivo com a tool Write e rode `node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal < arquivo.json`.
+Alternativa mais confiável no Windows/git-bash — heredocs podem falhar com `unexpected EOF` por causa de finais de linha CRLF quebrando o delimitador: grave o JSON num arquivo (tool Write) e use `--file`, sem precisar de stdin/heredoc:
+
+```bash
+node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal --file arquivo.json
+```
 
 Mostre os eventos confirmados de hoje. Com as tarefas do STEP 3 (já ajustadas, na ordem de prioridade) e os horários livres entre eventos, sugira blocos de tempo para as 1–3 tarefas mais importantes — em caso de empate de urgência, prefira a tarefa ligada ao projeto de maior prioridade do sprint (STEP 1) — sem sobrepor os eventos já confirmados. Pergunte se quer criar/ajustar esses blocos no calendário.
 

--- a/day-wrap.md
+++ b/day-wrap.md
@@ -60,18 +60,18 @@ Execute **sem pedir permissão**:
 
 **Filtro obrigatório.** Passe o array de eventos bruto do MCP por `filter-gcal` ANTES de qualquer outro uso — inclusive contagem, sumarização ou exibição parcial. O subcomando já deriva `myResponseStatus` internamente a partir de `attendees[].self` (sem `attendees` → trata como `"accepted"`) e descarta tudo que não seja `accepted` — convites ainda não respondidos não entram na lista. Não precompute o campo. Bypass do filtro (ex.: parsear o JSON diretamente em Node one-liner) reintroduz os bugs que o filtro foi criado para evitar.
 
-Passe o JSON via heredoc (evita quoting issues com aspas, backticks, `$`):
+Grave o JSON num arquivo (tool Write) e passe via `--file` — mais confiável que heredoc no Windows/git-bash, onde heredocs podem falhar com `unexpected EOF` por causa de finais de linha CRLF quebrando o delimitador:
+
+```bash
+node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal --file arquivo.json
+```
+
+Alternativa (evita o arquivo intermediário, mas sujeita ao problema de CRLF acima): heredoc via stdin, com aspas simples no delimitador para evitar quoting issues com aspas, backticks, `$`:
 
 ```bash
 node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal <<'JSON'
 {aqui-cola-o-array-de-eventos-do-MCP, sem processamento}
 JSON
-```
-
-Alternativa mais confiável no Windows/git-bash — heredocs podem falhar com `unexpected EOF` por causa de finais de linha CRLF quebrando o delimitador: grave o JSON num arquivo (tool Write) e use `--file`, sem precisar de stdin/heredoc:
-
-```bash
-node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal --file arquivo.json
 ```
 
 Mostre os eventos confirmados de amanhã. Ajude a encaixar as tarefas do STEP 5 nos horários livres — pergunte se quer criar/ajustar blocos.
@@ -93,6 +93,8 @@ node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts append-day-log --repo <<REPO_PATH>> 
 output: [output do usuário] | blocker: [bloqueio ou "none"] | improvements: [resumo do STEP 2] | health: [resumo do STEP 3]
 TEXT
 ```
+
+Se o heredoc falhar com `unexpected EOF` (comum no Windows/git-bash por causa de finais de linha CRLF), grave a linha num arquivo (tool Write) e use `--file` em vez de stdin/heredoc: `append-day-log --repo <<REPO_PATH>> --date YYYY-MM-DD --file arquivo.txt`.
 
 Substitua `YYYY-MM-DD` pela data de hoje. Esse log (`day-log.md`, mesmo diretório de `sprint-wip.md`) é o que torna a reconstrução do próximo Sprint Review mais leve — reduz a necessidade de varrer TickTick/Calendar/Gmail/transcripts do zero.
 

--- a/day-wrap.md
+++ b/day-wrap.md
@@ -68,7 +68,11 @@ node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal <<'JSON'
 JSON
 ```
 
-Se o heredoc falhar com `unexpected EOF` (comum no Windows/git-bash, geralmente por causa de finais de linha CRLF quebrando o delimitador), use o fallback: grave o JSON num arquivo com a tool Write e rode `node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal < arquivo.json`.
+Alternativa mais confiável no Windows/git-bash — heredocs podem falhar com `unexpected EOF` por causa de finais de linha CRLF quebrando o delimitador: grave o JSON num arquivo (tool Write) e use `--file`, sem precisar de stdin/heredoc:
+
+```bash
+node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal --file arquivo.json
+```
 
 Mostre os eventos confirmados de amanhã. Ajude a encaixar as tarefas do STEP 5 nos horários livres — pergunte se quer criar/ajustar blocos.
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "check-sync": "node build.js --check",
     "install-skills": "bash bin/install-skills.sh",
     "check-skills": "bash bin/check-skills.sh",
-    "test": "node --test __tests__/parser.test.js __tests__/insert.test.js __tests__/skill-checks.test.js && node -r tsx/cjs --test __tests__/period.test.ts __tests__/archive.test.ts __tests__/trends.test.ts __tests__/wip.test.ts __tests__/document.test.ts __tests__/paths.test.ts __tests__/filters.test.ts __tests__/cli.test.ts __tests__/daylog.test.ts"
+    "test": "node --test __tests__/parser.test.js __tests__/insert.test.js __tests__/skill-checks.test.js && node -r tsx/cjs --test __tests__/period.test.ts __tests__/archive.test.ts __tests__/trends.test.ts __tests__/wip.test.ts __tests__/document.test.ts __tests__/paths.test.ts __tests__/filters.test.ts __tests__/cli.test.ts __tests__/daylog.test.ts __tests__/skill-consistency.test.ts"
   },
   "engines": {
     "node": ">=18"

--- a/shared/filter-heredoc-block.md
+++ b/shared/filter-heredoc-block.md
@@ -1,0 +1,13 @@
+Passe o JSON via heredoc (evita quoting issues com aspas, backticks, `$`):
+
+```bash
+node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal <<'JSON'
+{aqui-cola-o-array-de-eventos-do-MCP, sem processamento}
+JSON
+```
+
+Alternativa mais confiável no Windows/git-bash — heredocs podem falhar com `unexpected EOF` por causa de finais de linha CRLF quebrando o delimitador: grave o JSON num arquivo (tool Write) e use `--file`, sem precisar de stdin/heredoc:
+
+```bash
+node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal --file arquivo.json
+```

--- a/shared/filter-heredoc-block.md
+++ b/shared/filter-heredoc-block.md
@@ -1,13 +1,13 @@
-Passe o JSON via heredoc (evita quoting issues com aspas, backticks, `$`):
+Grave o JSON num arquivo (tool Write) e passe via `--file` — mais confiável que heredoc no Windows/git-bash, onde heredocs podem falhar com `unexpected EOF` por causa de finais de linha CRLF quebrando o delimitador:
+
+```bash
+node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal --file arquivo.json
+```
+
+Alternativa (evita o arquivo intermediário, mas sujeita ao problema de CRLF acima): heredoc via stdin, com aspas simples no delimitador para evitar quoting issues com aspas, backticks, `$`:
 
 ```bash
 node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal <<'JSON'
 {aqui-cola-o-array-de-eventos-do-MCP, sem processamento}
 JSON
-```
-
-Alternativa mais confiável no Windows/git-bash — heredocs podem falhar com `unexpected EOF` por causa de finais de linha CRLF quebrando o delimitador: grave o JSON num arquivo (tool Write) e use `--file`, sem precisar de stdin/heredoc:
-
-```bash
-node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal --file arquivo.json
 ```

--- a/shared/language-block.md
+++ b/shared/language-block.md
@@ -1,0 +1,3 @@
+## Language
+
+**IMPORTANT:** Estas instruções estão em português apenas para quem as edita — responda ao usuário **sempre em inglês**, mesmo que ele escreva em português. Ao persistir texto redigido pelo assistente (day-log, sprint-wip), traduza para inglês antes de gravar; não persista texto em português. Exceção: títulos de tasks no TickTick — preserve exatamente como o usuário digitou, não traduza.

--- a/sprint-close.md
+++ b/sprint-close.md
@@ -31,18 +31,18 @@ Execute em paralelo **sem pedir permissão** (período = `generated_at` do rascu
 
 **Filtro obrigatório.** Após cada chamada MCP (`gcal_list_events`, `gmail_search_messages`), passe o resultado bruto pelo subcomando correspondente ANTES de qualquer outro uso. Para `gcal_list_events`, não precompute nada — `filter-gcal` já deriva `myResponseStatus` internamente a partir de `attendees[].self` (sem `attendees` → trata como `"accepted"`) e descarta o que não for `accepted`. Bypass do filtro reintroduz os bugs que ele foi criado para evitar.
 
-Passe o JSON via heredoc (evita quoting issues com aspas, backticks, `$`):
+Grave o JSON num arquivo (tool Write) e passe via `--file` — mais confiável que heredoc no Windows/git-bash, onde heredocs podem falhar com `unexpected EOF` por causa de finais de linha CRLF quebrando o delimitador:
+
+```bash
+node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal --file arquivo.json
+```
+
+Alternativa (evita o arquivo intermediário, mas sujeita ao problema de CRLF acima): heredoc via stdin, com aspas simples no delimitador para evitar quoting issues com aspas, backticks, `$`:
 
 ```bash
 node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal <<'JSON'
 {aqui-cola-o-array-de-eventos-do-MCP, sem processamento}
 JSON
-```
-
-Alternativa mais confiável no Windows/git-bash — heredocs podem falhar com `unexpected EOF` por causa de finais de linha CRLF quebrando o delimitador: grave o JSON num arquivo (tool Write) e use `--file`, sem precisar de stdin/heredoc:
-
-```bash
-node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal --file arquivo.json
 ```
 
 Use `filter-gmail` da mesma forma. Cada comando lê do stdin e retorna o array filtrado em stdout.

--- a/sprint-close.md
+++ b/sprint-close.md
@@ -1,6 +1,6 @@
 ## Language
 
-**IMPORTANT:** Estas instruções estão em português apenas para quem as edita — responda ao usuário **sempre em inglês**, mesmo que ele escreva em português. Ao persistir texto (sprint-wip, day-log), traduza para inglês antes de gravar; não persista texto em português.
+**IMPORTANT:** Estas instruções estão em português apenas para quem as edita — responda ao usuário **sempre em inglês**, mesmo que ele escreva em português. Ao persistir texto redigido pelo assistente (day-log, sprint-wip), traduza para inglês antes de gravar; não persista texto em português. Exceção: títulos de tasks no TickTick — preserve exatamente como o usuário digitou, não traduza.
 
 ---
 
@@ -31,7 +31,7 @@ Execute em paralelo **sem pedir permissão** (período = `generated_at` do rascu
 
 **Filtro obrigatório.** Após cada chamada MCP (`gcal_list_events`, `gmail_search_messages`), passe o resultado bruto pelo subcomando correspondente ANTES de qualquer outro uso. Para `gcal_list_events`, não precompute nada — `filter-gcal` já deriva `myResponseStatus` internamente a partir de `attendees[].self` (sem `attendees` → trata como `"accepted"`) e descarta o que não for `accepted`. Bypass do filtro reintroduz os bugs que ele foi criado para evitar.
 
-Para os filtros, passe o JSON via heredoc:
+Passe o JSON via heredoc (evita quoting issues com aspas, backticks, `$`):
 
 ```bash
 node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal <<'JSON'
@@ -39,7 +39,11 @@ node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal <<'JSON'
 JSON
 ```
 
-Se o heredoc falhar com `unexpected EOF` (comum no Windows/git-bash, geralmente por causa de finais de linha CRLF quebrando o delimitador), use o fallback: grave o JSON num arquivo com a tool Write e rode `node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal < arquivo.json`.
+Alternativa mais confiável no Windows/git-bash — heredocs podem falhar com `unexpected EOF` por causa de finais de linha CRLF quebrando o delimitador: grave o JSON num arquivo (tool Write) e use `--file`, sem precisar de stdin/heredoc:
+
+```bash
+node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal --file arquivo.json
+```
 
 Use `filter-gmail` da mesma forma. Cada comando lê do stdin e retorna o array filtrado em stdout.
 

--- a/sprint-start.md
+++ b/sprint-start.md
@@ -74,18 +74,18 @@ Execute em paralelo **sem pedir permissão**:
 
 **Filtro obrigatório.** Após CADA chamada MCP (`gcal_list_events`, `gmail_search_messages`, `gh api events`), passe o resultado bruto pelo subcomando correspondente ANTES de qualquer outro uso — inclusive contagem, sumarização ou exibição parcial. Para `gcal_list_events`, não precompute nada — `filter-gcal` já deriva `myResponseStatus` internamente a partir de `attendees[].self` (sem `attendees` → trata como `"accepted"`) e descarta o que não for `accepted`. Bypass do filtro (ex.: parsear o JSON diretamente em Node one-liner) reintroduz os bugs que o filtro foi criado para evitar.
 
-Passe o JSON via heredoc (evita quoting issues com aspas, backticks, `$`):
+Grave o JSON num arquivo (tool Write) e passe via `--file` — mais confiável que heredoc no Windows/git-bash, onde heredocs podem falhar com `unexpected EOF` por causa de finais de linha CRLF quebrando o delimitador:
+
+```bash
+node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal --file arquivo.json
+```
+
+Alternativa (evita o arquivo intermediário, mas sujeita ao problema de CRLF acima): heredoc via stdin, com aspas simples no delimitador para evitar quoting issues com aspas, backticks, `$`:
 
 ```bash
 node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal <<'JSON'
 {aqui-cola-o-array-de-eventos-do-MCP, sem processamento}
 JSON
-```
-
-Alternativa mais confiável no Windows/git-bash — heredocs podem falhar com `unexpected EOF` por causa de finais de linha CRLF quebrando o delimitador: grave o JSON num arquivo (tool Write) e use `--file`, sem precisar de stdin/heredoc:
-
-```bash
-node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal --file arquivo.json
 ```
 
 Use `filter-gmail` (sem flags) e `filter-github --start current.start --end current.end` para os outros dois. Cada comando lê do stdin e retorna o array filtrado em stdout.

--- a/sprint-start.md
+++ b/sprint-start.md
@@ -1,6 +1,6 @@
 ## Language
 
-**IMPORTANT:** Estas instruções estão em português apenas para quem as edita — responda ao usuário **sempre em inglês**, mesmo que ele escreva em português. Ao persistir texto (sprint-wip, day-log), traduza para inglês antes de gravar; não persista texto em português.
+**IMPORTANT:** Estas instruções estão em português apenas para quem as edita — responda ao usuário **sempre em inglês**, mesmo que ele escreva em português. Ao persistir texto redigido pelo assistente (day-log, sprint-wip), traduza para inglês antes de gravar; não persista texto em português. Exceção: títulos de tasks no TickTick — preserve exatamente como o usuário digitou, não traduza.
 
 ---
 
@@ -82,7 +82,11 @@ node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal <<'JSON'
 JSON
 ```
 
-Se o heredoc falhar com `unexpected EOF` (comum no Windows/git-bash, geralmente por causa de finais de linha CRLF quebrando o delimitador), use o fallback: grave o JSON num arquivo com a tool Write e rode `node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal < arquivo.json`.
+Alternativa mais confiável no Windows/git-bash — heredocs podem falhar com `unexpected EOF` por causa de finais de linha CRLF quebrando o delimitador: grave o JSON num arquivo (tool Write) e use `--file`, sem precisar de stdin/heredoc:
+
+```bash
+node -r tsx/cjs <<REPO_PATH>>/bin/sprint.ts filter-gcal --file arquivo.json
+```
 
 Use `filter-gmail` (sem flags) e `filter-github --start current.start --end current.end` para os outros dois. Cada comando lê do stdin e retorna o array filtrado em stdout.
 


### PR DESCRIPTION
## Summary
- `bin/sprint.ts`: `filter-gcal`/`filter-gmail`/`filter-github` now accept `--file <path>` as a first-class alternative to stdin/heredoc — no more relying on shell `<` redirection as an undocumented-in-code workaround for the Windows/git-bash heredoc CRLF `unexpected EOF` failure (closes #105)
- Extracted the duplicated "Language" rule and filter-usage heredoc/`--file` block into `shared/*.md`, with a new CI-enforced test (`__tests__/skill-consistency.test.ts`) that fails the build if `day-plan.md`/`day-wrap.md`/`sprint-close.md`/`sprint-start.md` drifts from the shared source (closes #106)
- Along the way, unified the "Language" wording that had already drifted between day-plan/day-wrap and sprint-close/sprint-start (the latter two were missing the TickTick-title exception clause)

## Test plan
- [x] `npm test` — 136/136 passing, including 3 new `--file` CLI tests and 8 new skill-consistency tests