### PR TITLE
fix: auto re-sync skill files into ~/.claude/commands after pull/checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ See [SETUP.md](SETUP.md) for complete configuration instructions.
 
 ## Setup
 
-1. **Install the skill files** with `npm run install-skills` (or `bash bin/install-skills.sh`) — the script substitutes the `<<REPO_PATH>>` placeholder with your clone's path and writes the result to `~/.claude/commands/`. `npm install` also wires up git hooks (`post-merge`/`post-checkout`) that re-run this automatically after a pull or branch switch, so the installed copies don't drift from the repo — run `npm run check-installed-skills` if you want to double-check they're in sync. See [SETUP.md → Step 6](SETUP.md#step-6-install-skill-files) for details.
+1. **Install the skill files** with `npm run install-skills` (or `bash bin/install-skills.sh`) — the script substitutes the `<<REPO_PATH>>` placeholder with your clone's path and writes the result to `~/.claude/commands/`. `npm install` also wires up git hooks (`post-merge`/`post-checkout`) that re-run this automatically after every pull or branch switch **from then on** — but that only takes effect once `npm install` (or `npm run setup-hooks`) has actually run on your clone, so run it once after pulling any change that touches the skill files. Run `npm run check-installed-skills` any time you want to double-check they're in sync. See [SETUP.md → Step 6](SETUP.md#step-6-install-skill-files) for details.
 2. **Adapt the project list** — the shipped `sprint-start.md` STEP 4a/4c includes the maintainer's own projects (Diar.ia, Clarice, Jandig, …) as concrete examples. Replace those project names with your own; the Outputs/Outcomes structure stays.
 3. **Adjust the improvement goals** if yours differ from the defaults (`Work +2h`, `OoH`, `Make impact`).
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ See [SETUP.md](SETUP.md) for complete configuration instructions.
 
 ## Setup
 
-1. **Install the skill files** with `npm run install-skills` (or `bash bin/install-skills.sh`) — the script substitutes the `<<REPO_PATH>>` placeholder with your clone's path and writes the result to `~/.claude/commands/`. See [SETUP.md → Step 6](SETUP.md#step-6-install-skill-files) for details.
+1. **Install the skill files** with `npm run install-skills` (or `bash bin/install-skills.sh`) — the script substitutes the `<<REPO_PATH>>` placeholder with your clone's path and writes the result to `~/.claude/commands/`. `npm install` also wires up git hooks (`post-merge`/`post-checkout`) that re-run this automatically after a pull or branch switch, so the installed copies don't drift from the repo — run `npm run check-installed-skills` if you want to double-check they're in sync. See [SETUP.md → Step 6](SETUP.md#step-6-install-skill-files) for details.
 2. **Adapt the project list** — the shipped `sprint-start.md` STEP 4a/4c includes the maintainer's own projects (Diar.ia, Clarice, Jandig, …) as concrete examples. Replace those project names with your own; the Outputs/Outcomes structure stays.
 3. **Adjust the improvement goals** if yours differ from the defaults (`Work +2h`, `OoH`, `Make impact`).
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -101,7 +101,9 @@ The script:
 - Writes the materialized result to `~/.claude/commands/` (default)
 - Replaces any pre-existing symlink at the destination with a real file (avoids the placeholder reaching Claude Code through a back-link to the repo)
 
-**This re-syncs automatically after that.** `npm install` also runs `bin/setup-hooks.sh`, which points git's `core.hooksPath` at the repo-tracked `bin/hooks/` — so `post-merge` (after `git pull`/merge) and `post-checkout` (after switching branches) re-run `install-skills.sh` for you. If you ever suspect the installed copies have drifted (e.g. you edited a skill file without pulling/checking out), run `npm run check-installed-skills` to compare them against the repo and get a list of what's stale. See issue #108.
+**This re-syncs automatically from now on.** `npm install` also runs `bin/setup-hooks.js` (`postinstall`), which points git's `core.hooksPath` at the repo-tracked `bin/hooks/` — so `post-merge` (after `git pull`/merge) and `post-checkout` (after switching branches) re-run `install-skills.sh` for you.
+
+That auto-sync only exists *after* the hooks are wired up, though — if you already had this repo cloned before `bin/hooks/` and this `postinstall` script existed, a plain `git pull` alone won't activate it (`postinstall` only fires on an explicit `npm install`/`npm ci`). Run `npm install` (or `npm run setup-hooks`) once after pulling this to bootstrap it; every pull/checkout after that self-syncs. If you ever suspect the installed copies have drifted (e.g. hooks were never wired up, or you edited a skill file without pulling/checking out), run `npm run check-installed-skills` to compare them against the repo and get a list of what's stale. See issue #108.
 
 ### Step 7: Run the Workflow
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -101,7 +101,7 @@ The script:
 - Writes the materialized result to `~/.claude/commands/` (default)
 - Replaces any pre-existing symlink at the destination with a real file (avoids the placeholder reaching Claude Code through a back-link to the repo)
 
-Re-run after pulling updates that touch the skill files.
+**This re-syncs automatically after that.** `npm install` also runs `bin/setup-hooks.sh`, which points git's `core.hooksPath` at the repo-tracked `bin/hooks/` — so `post-merge` (after `git pull`/merge) and `post-checkout` (after switching branches) re-run `install-skills.sh` for you. If you ever suspect the installed copies have drifted (e.g. you edited a skill file without pulling/checking out), run `npm run check-installed-skills` to compare them against the repo and get a list of what's stale. See issue #108.
 
 ### Step 7: Run the Workflow
 

--- a/__tests__/skill-sync.test.js
+++ b/__tests__/skill-sync.test.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const CHECK_INSTALLED = path.join(REPO_ROOT, 'bin', 'check-installed-skills.sh');
+const INSTALL = path.join(REPO_ROOT, 'bin', 'install-skills.sh');
+const SETUP_HOOKS = path.join(REPO_ROOT, 'bin', 'setup-hooks.sh');
+const POST_MERGE = path.join(REPO_ROOT, 'bin', 'hooks', 'post-merge');
+const POST_CHECKOUT = path.join(REPO_ROOT, 'bin', 'hooks', 'post-checkout');
+
+function runCheckInstalled(installedDir) {
+  const args = installedDir ? [CHECK_INSTALLED, installedDir] : [CHECK_INSTALLED];
+  return spawnSync('bash', args, { encoding: 'utf8' });
+}
+
+function freshInstall() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'installed-'));
+  const r = spawnSync('bash', [INSTALL, dir], { encoding: 'utf8' });
+  assert.equal(r.status, 0, `install-skills.sh failed: ${r.stderr}`);
+  return dir;
+}
+
+test('check-installed-skills.sh passes when installed copies match a fresh install', () => {
+  const dir = freshInstall();
+  const r = runCheckInstalled(dir);
+  assert.equal(r.status, 0, `expected exit 0; stdout=${r.stdout} stderr=${r.stderr}`);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('check-installed-skills.sh detects a stale installed file', () => {
+  const dir = freshInstall();
+  fs.writeFileSync(path.join(dir, 'day-plan.md'), '## PASSO 1: stale content\n');
+
+  const r = runCheckInstalled(dir);
+  assert.equal(r.status, 1, 'expected exit 1 on stale installed file');
+  assert.match(r.stderr, /day-plan\.md/);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('check-installed-skills.sh detects a missing installed file', () => {
+  const dir = freshInstall();
+  fs.unlinkSync(path.join(dir, 'day-wrap.md'));
+
+  const r = runCheckInstalled(dir);
+  assert.equal(r.status, 1, 'expected exit 1 on missing installed file');
+  assert.match(r.stderr, /day-wrap\.md/);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('check-installed-skills.sh exits 0 when the installed dir does not exist', () => {
+  const missing = path.join(os.tmpdir(), `no-such-installed-dir-${process.pid}`);
+  const r = runCheckInstalled(missing);
+  assert.equal(r.status, 0, `expected exit 0 for missing installed dir; stderr=${r.stderr}`);
+});
+
+test('setup-hooks.sh exits 0 gracefully outside a git repo', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'not-a-repo-'));
+  fs.mkdirSync(path.join(dir, 'bin', 'hooks'), { recursive: true });
+  fs.copyFileSync(SETUP_HOOKS, path.join(dir, 'bin', 'setup-hooks.sh'));
+  fs.copyFileSync(POST_MERGE, path.join(dir, 'bin', 'hooks', 'post-merge'));
+  fs.copyFileSync(POST_CHECKOUT, path.join(dir, 'bin', 'hooks', 'post-checkout'));
+
+  const r = spawnSync('bash', [path.join(dir, 'bin', 'setup-hooks.sh')], { cwd: dir, encoding: 'utf8' });
+  assert.equal(r.status, 0, `expected exit 0 outside git repo; stderr=${r.stderr}`);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('setup-hooks.sh wires post-checkout to auto re-sync skill files', () => {
+  const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hooks-repo-'));
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hooks-home-'));
+
+  try {
+    const env = {
+      ...process.env,
+      HOME: homeDir,
+      GIT_AUTHOR_NAME: 'test',
+      GIT_AUTHOR_EMAIL: 'test@example.com',
+      GIT_COMMITTER_NAME: 'test',
+      GIT_COMMITTER_EMAIL: 'test@example.com',
+    };
+    const git = (args) => spawnSync('git', args, { cwd: repoDir, encoding: 'utf8', env });
+
+    assert.equal(git(['-c', 'init.defaultBranch=main', 'init']).status, 0);
+    git(['config', 'commit.gpgsign', 'false']);
+
+    fs.mkdirSync(path.join(repoDir, 'bin', 'hooks'), { recursive: true });
+    fs.copyFileSync(SETUP_HOOKS, path.join(repoDir, 'bin', 'setup-hooks.sh'));
+    fs.copyFileSync(INSTALL, path.join(repoDir, 'bin', 'install-skills.sh'));
+    fs.copyFileSync(POST_MERGE, path.join(repoDir, 'bin', 'hooks', 'post-merge'));
+    fs.copyFileSync(POST_CHECKOUT, path.join(repoDir, 'bin', 'hooks', 'post-checkout'));
+    fs.writeFileSync(path.join(repoDir, 'day-plan.md'), '## fixture content\n');
+
+    assert.equal(git(['add', '-A']).status, 0);
+    assert.equal(git(['commit', '-m', 'initial']).status, 0);
+
+    const setup = spawnSync('bash', [path.join(repoDir, 'bin', 'setup-hooks.sh')], {
+      cwd: repoDir,
+      encoding: 'utf8',
+      env,
+    });
+    assert.equal(setup.status, 0, `setup-hooks.sh failed: ${setup.stderr}`);
+    assert.equal(git(['config', '--get', 'core.hooksPath']).stdout.trim(), 'bin/hooks');
+
+    // Creating+switching to a branch fires post-checkout, which should
+    // re-run install-skills.sh against the overridden $HOME.
+    const checkout = git(['checkout', '-b', 'other']);
+    assert.equal(checkout.status, 0, `checkout failed: ${checkout.stderr}`);
+    assert.match(checkout.stdout + checkout.stderr, /post-checkout: skill files re-synced/);
+
+    const materialized = path.join(homeDir, '.claude', 'commands', 'day-plan.md');
+    assert.ok(fs.existsSync(materialized), 'expected day-plan.md to be materialized via the hook');
+    assert.equal(fs.readFileSync(materialized, 'utf8'), '## fixture content\n');
+  } finally {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});

--- a/__tests__/skill-sync.test.js
+++ b/__tests__/skill-sync.test.js
@@ -11,8 +11,10 @@ const REPO_ROOT = path.resolve(__dirname, '..');
 const CHECK_INSTALLED = path.join(REPO_ROOT, 'bin', 'check-installed-skills.sh');
 const INSTALL = path.join(REPO_ROOT, 'bin', 'install-skills.sh');
 const SETUP_HOOKS = path.join(REPO_ROOT, 'bin', 'setup-hooks.sh');
+const SETUP_HOOKS_JS = path.join(REPO_ROOT, 'bin', 'setup-hooks.js');
 const POST_MERGE = path.join(REPO_ROOT, 'bin', 'hooks', 'post-merge');
 const POST_CHECKOUT = path.join(REPO_ROOT, 'bin', 'hooks', 'post-checkout');
+const RESYNC = path.join(REPO_ROOT, 'bin', 'hooks', '_resync.sh');
 
 function runCheckInstalled(installedDir) {
   const args = installedDir ? [CHECK_INSTALLED, installedDir] : [CHECK_INSTALLED];
@@ -24,6 +26,42 @@ function freshInstall() {
   const r = spawnSync('bash', [INSTALL, dir], { encoding: 'utf8' });
   assert.equal(r.status, 0, `install-skills.sh failed: ${r.stderr}`);
   return dir;
+}
+
+function gitEnv(extra) {
+  return {
+    ...process.env,
+    GIT_AUTHOR_NAME: 'test',
+    GIT_AUTHOR_EMAIL: 'test@example.com',
+    GIT_COMMITTER_NAME: 'test',
+    GIT_COMMITTER_EMAIL: 'test@example.com',
+    ...extra,
+  };
+}
+
+// Scaffolds a throwaway repo with the hook plumbing copied in, so tests don't
+// touch this repo's own git config or hooks.
+function scaffoldHookRepo(repoDir, env) {
+  const git = (args, cwd = repoDir) => spawnSync('git', args, { cwd, encoding: 'utf8', env });
+
+  assert.equal(git(['-c', 'init.defaultBranch=main', 'init']).status, 0);
+  git(['config', 'commit.gpgsign', 'false']);
+
+  fs.mkdirSync(path.join(repoDir, 'bin', 'hooks'), { recursive: true });
+  fs.copyFileSync(SETUP_HOOKS, path.join(repoDir, 'bin', 'setup-hooks.sh'));
+  fs.copyFileSync(INSTALL, path.join(repoDir, 'bin', 'install-skills.sh'));
+  fs.copyFileSync(POST_MERGE, path.join(repoDir, 'bin', 'hooks', 'post-merge'));
+  fs.copyFileSync(POST_CHECKOUT, path.join(repoDir, 'bin', 'hooks', 'post-checkout'));
+  fs.copyFileSync(RESYNC, path.join(repoDir, 'bin', 'hooks', '_resync.sh'));
+
+  return git;
+}
+
+function envWithoutBash() {
+  // Restrict PATH to node's own directory so `bash` can't resolve, without
+  // breaking the outer node invocation (spawned via process.execPath, an
+  // absolute path that doesn't need PATH resolution at all).
+  return { ...process.env, PATH: path.dirname(process.execPath) };
 }
 
 test('check-installed-skills.sh passes when installed copies match a fresh install', () => {
@@ -71,31 +109,57 @@ test('setup-hooks.sh exits 0 gracefully outside a git repo', () => {
   fs.rmSync(dir, { recursive: true, force: true });
 });
 
+test('setup-hooks.sh does not clobber a pre-existing different core.hooksPath', () => {
+  const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hooks-repo-'));
+  try {
+    const env = gitEnv();
+    const git = (args) => spawnSync('git', args, { cwd: repoDir, encoding: 'utf8', env });
+
+    assert.equal(git(['-c', 'init.defaultBranch=main', 'init']).status, 0);
+    git(['config', 'core.hooksPath', 'some-other-hooks-dir']);
+
+    fs.mkdirSync(path.join(repoDir, 'bin', 'hooks'), { recursive: true });
+    fs.copyFileSync(SETUP_HOOKS, path.join(repoDir, 'bin', 'setup-hooks.sh'));
+
+    const setup = spawnSync('bash', [path.join(repoDir, 'bin', 'setup-hooks.sh')], {
+      cwd: repoDir,
+      encoding: 'utf8',
+      env,
+    });
+    assert.equal(setup.status, 0, `expected graceful exit 0; stderr=${setup.stderr}`);
+    assert.match(setup.stderr, /already set to 'some-other-hooks-dir'/);
+    assert.equal(git(['config', '--get', 'core.hooksPath']).stdout.trim(), 'some-other-hooks-dir');
+  } finally {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+  }
+});
+
+test('setup-hooks.js --soft never fails even when bash is unavailable', () => {
+  const r = spawnSync(process.execPath, [SETUP_HOOKS_JS, '--soft'], {
+    encoding: 'utf8',
+    env: envWithoutBash(),
+  });
+  assert.equal(r.status, 0, `expected soft mode to exit 0; stdout=${r.stdout} stderr=${r.stderr}`);
+  assert.match(r.stdout + r.stderr, /bash not found/i);
+});
+
+test('setup-hooks.js (hard mode) surfaces failure when bash is unavailable', () => {
+  const r = spawnSync(process.execPath, [SETUP_HOOKS_JS], {
+    encoding: 'utf8',
+    env: envWithoutBash(),
+  });
+  assert.notEqual(r.status, 0, 'expected hard mode to propagate a non-zero exit without bash');
+});
+
 test('setup-hooks.sh wires post-checkout to auto re-sync skill files', () => {
   const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hooks-repo-'));
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hooks-home-'));
 
   try {
-    const env = {
-      ...process.env,
-      HOME: homeDir,
-      GIT_AUTHOR_NAME: 'test',
-      GIT_AUTHOR_EMAIL: 'test@example.com',
-      GIT_COMMITTER_NAME: 'test',
-      GIT_COMMITTER_EMAIL: 'test@example.com',
-    };
-    const git = (args) => spawnSync('git', args, { cwd: repoDir, encoding: 'utf8', env });
+    const env = gitEnv({ HOME: homeDir });
+    const git = scaffoldHookRepo(repoDir, env);
 
-    assert.equal(git(['-c', 'init.defaultBranch=main', 'init']).status, 0);
-    git(['config', 'commit.gpgsign', 'false']);
-
-    fs.mkdirSync(path.join(repoDir, 'bin', 'hooks'), { recursive: true });
-    fs.copyFileSync(SETUP_HOOKS, path.join(repoDir, 'bin', 'setup-hooks.sh'));
-    fs.copyFileSync(INSTALL, path.join(repoDir, 'bin', 'install-skills.sh'));
-    fs.copyFileSync(POST_MERGE, path.join(repoDir, 'bin', 'hooks', 'post-merge'));
-    fs.copyFileSync(POST_CHECKOUT, path.join(repoDir, 'bin', 'hooks', 'post-checkout'));
     fs.writeFileSync(path.join(repoDir, 'day-plan.md'), '## fixture content\n');
-
     assert.equal(git(['add', '-A']).status, 0);
     assert.equal(git(['commit', '-m', 'initial']).status, 0);
 
@@ -117,6 +181,57 @@ test('setup-hooks.sh wires post-checkout to auto re-sync skill files', () => {
     assert.ok(fs.existsSync(materialized), 'expected day-plan.md to be materialized via the hook');
     assert.equal(fs.readFileSync(materialized, 'utf8'), '## fixture content\n');
   } finally {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test('post-checkout resolves the main worktree path, not a linked worktree\'s ephemeral path', () => {
+  const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hooks-repo-'));
+  const worktreeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hooks-worktree-'));
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hooks-home-'));
+
+  try {
+    const env = gitEnv({ HOME: homeDir });
+    const git = scaffoldHookRepo(repoDir, env);
+
+    fs.writeFileSync(path.join(repoDir, 'day-plan.md'), 'Run <<REPO_PATH>>/bin/sprint.ts\n');
+    assert.equal(git(['add', '-A']).status, 0);
+    assert.equal(git(['commit', '-m', 'initial']).status, 0);
+
+    const setup = spawnSync('bash', [path.join(repoDir, 'bin', 'setup-hooks.sh')], {
+      cwd: repoDir,
+      encoding: 'utf8',
+      env,
+    });
+    assert.equal(setup.status, 0, `setup-hooks.sh failed: ${setup.stderr}`);
+
+    assert.equal(git(['branch', 'wt-branch']).status, 0);
+    const wtAdd = git(['worktree', 'add', worktreeDir, 'wt-branch']);
+    assert.equal(wtAdd.status, 0, `worktree add failed: ${wtAdd.stderr}`);
+
+    // core.hooksPath is shared across worktrees; a checkout fired FROM the
+    // linked worktree must still resolve <<REPO_PATH>> to the main repo dir.
+    const wtCheckout = git(['checkout', '-b', 'wt-branch-2'], worktreeDir);
+    assert.equal(wtCheckout.status, 0, `checkout inside worktree failed: ${wtCheckout.stderr}`);
+    assert.match(wtCheckout.stdout + wtCheckout.stderr, /post-checkout: skill files re-synced/);
+
+    const materialized = path.join(homeDir, '.claude', 'commands', 'day-plan.md');
+    assert.ok(fs.existsSync(materialized), 'expected day-plan.md to be materialized via the worktree-triggered hook');
+
+    // Compare basenames rather than full paths: bash on Windows (MSYS)
+    // translates the Windows temp path (e.g. C:\Users\...\Temp\hooks-repo-X)
+    // to its own mount form (e.g. /tmp/hooks-repo-X), so a raw string/format
+    // match on the original Windows path would false-negative even when the
+    // fix is working correctly. The mkdtemp-generated basename survives that
+    // translation unchanged and uniquely identifies which dir was used.
+    const body = fs.readFileSync(materialized, 'utf8');
+    const repoDirBase = path.basename(fs.realpathSync(repoDir));
+    const worktreeDirBase = path.basename(worktreeDir);
+    assert.ok(!body.includes(worktreeDirBase), `REPO_PATH must not point at the disposable worktree; got: ${body}`);
+    assert.ok(body.includes(repoDirBase), `expected REPO_PATH to resolve to the main repo dir (${repoDirBase}); got: ${body}`);
+  } finally {
+    fs.rmSync(worktreeDir, { recursive: true, force: true });
     fs.rmSync(repoDir, { recursive: true, force: true });
     fs.rmSync(homeDir, { recursive: true, force: true });
   }

--- a/bin/check-installed-skills.sh
+++ b/bin/check-installed-skills.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Detect drift between the repo's skill .md files and the materialized
+# copies that install-skills.sh already wrote out (default ~/.claude/commands).
+#
+# Unlike check-skills.sh (which runs in CI against a scratch temp dir and
+# never touches a real machine), this script is meant to run locally, since
+# CI has no access to the developer's ~/.claude/commands.
+#
+# Usage:
+#   bash bin/check-installed-skills.sh [installed-dir]
+#   npm run check-installed-skills
+#
+# Exit 0: installed copies match what the repo would produce, or the
+#         installed dir doesn't exist yet (nothing to compare).
+# Exit 1: one or more installed files are stale or missing.
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INSTALLED_DIR="${1:-${HOME}/.claude/commands}"
+
+if [ ! -d "$INSTALLED_DIR" ]; then
+  echo "installed dir not found: $INSTALLED_DIR — nothing to check" >&2
+  exit 0
+fi
+
+fresh="$(mktemp -d)"
+trap 'rm -rf "$fresh"' EXIT
+bash "$REPO_DIR/bin/install-skills.sh" "$fresh" >/dev/null
+
+stale=()
+for f in sprint-start.md sprint-update.md sprint-close.md day-plan.md day-wrap.md; do
+  expected="${fresh}/${f}"
+  [ -f "$expected" ] || continue
+
+  actual="${INSTALLED_DIR}/${f}"
+  if [ ! -f "$actual" ] || ! diff -q "$expected" "$actual" >/dev/null 2>&1; then
+    stale+=("$f")
+  fi
+done
+
+if [ "${#stale[@]}" -gt 0 ]; then
+  echo "::warning::Installed skill files are out of sync with the repo — run 'npm run install-skills' to update:" >&2
+  for f in "${stale[@]}"; do
+    echo "  - $f" >&2
+  done
+  exit 1
+fi
+
+echo "Installed skill files are in sync with the repo."

--- a/bin/check-installed-skills.sh
+++ b/bin/check-installed-skills.sh
@@ -29,9 +29,9 @@ trap 'rm -rf "$fresh"' EXIT
 bash "$REPO_DIR/bin/install-skills.sh" "$fresh" >/dev/null
 
 stale=()
-for f in sprint-start.md sprint-update.md sprint-close.md day-plan.md day-wrap.md; do
-  expected="${fresh}/${f}"
+for expected in "$fresh"/*.md; do
   [ -f "$expected" ] || continue
+  f="$(basename "$expected")"
 
   actual="${INSTALLED_DIR}/${f}"
   if [ ! -f "$actual" ] || ! diff -q "$expected" "$actual" >/dev/null 2>&1; then

--- a/bin/hooks/_resync.sh
+++ b/bin/hooks/_resync.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Shared body for bin/hooks/post-merge and bin/hooks/post-checkout. Not a git
+# hook itself (git only dispatches to exact hook names) — invoked by both via
+# `bash .../_resync.sh <label>`, so it doesn't need the executable bit.
+#
+# Resolves the MAIN worktree root, never the worktree the hook happened to
+# fire from. core.hooksPath is shared across every worktree of a repo, but
+# `git rev-parse --show-toplevel` returns the *current* worktree's path — and
+# a linked worktree is disposable. Materializing skill files with
+# <<REPO_PATH>> pointed at a worktree leaves ~/.claude/commands referencing a
+# path that vanishes the moment the worktree is removed. --git-common-dir
+# always points at the shared main .git directory regardless of which
+# worktree invokes it, so its parent is the stable path to substitute.
+set -euo pipefail
+
+label="${1:-hook}"
+
+main_git_dir="$(git rev-parse --path-format=absolute --git-common-dir)"
+REPO_DIR="$(cd "$(dirname "$main_git_dir")" && pwd)"
+
+bash "$REPO_DIR/bin/install-skills.sh" >/dev/null
+echo "${label}: skill files re-synced to ~/.claude/commands"

--- a/bin/hooks/post-checkout
+++ b/bin/hooks/post-checkout
@@ -6,6 +6,4 @@ set -euo pipefail
 
 [ "${3:-0}" = "1" ] || exit 0
 
-REPO_DIR="$(git rev-parse --show-toplevel)"
-bash "$REPO_DIR/bin/install-skills.sh" >/dev/null
-echo "post-checkout: skill files re-synced to ~/.claude/commands"
+exec bash "$(dirname "${BASH_SOURCE[0]}")/_resync.sh" "post-checkout"

--- a/bin/hooks/post-checkout
+++ b/bin/hooks/post-checkout
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Same purpose as bin/hooks/post-merge, but for branch switches. Git passes
+# post-checkout three args: previous HEAD, new HEAD, and a flag that's 1 for
+# a branch checkout and 0 for a plain file checkout — skip the latter.
+set -euo pipefail
+
+[ "${3:-0}" = "1" ] || exit 0
+
+REPO_DIR="$(git rev-parse --show-toplevel)"
+bash "$REPO_DIR/bin/install-skills.sh" >/dev/null
+echo "post-checkout: skill files re-synced to ~/.claude/commands"

--- a/bin/hooks/post-merge
+++ b/bin/hooks/post-merge
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Re-materialize skill files into ~/.claude/commands after a merge/pull, so
+# the installed copies never drift from the repo (see issue #108).
+# install-skills.sh is cheap and idempotent, so we just always re-run it
+# rather than diffing to decide whether a skill file actually changed.
+set -euo pipefail
+
+REPO_DIR="$(git rev-parse --show-toplevel)"
+bash "$REPO_DIR/bin/install-skills.sh" >/dev/null
+echo "post-merge: skill files re-synced to ~/.claude/commands"

--- a/bin/hooks/post-merge
+++ b/bin/hooks/post-merge
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 # Re-materialize skill files into ~/.claude/commands after a merge/pull, so
 # the installed copies never drift from the repo (see issue #108).
-# install-skills.sh is cheap and idempotent, so we just always re-run it
-# rather than diffing to decide whether a skill file actually changed.
 set -euo pipefail
 
-REPO_DIR="$(git rev-parse --show-toplevel)"
-bash "$REPO_DIR/bin/install-skills.sh" >/dev/null
-echo "post-merge: skill files re-synced to ~/.claude/commands"
+exec bash "$(dirname "${BASH_SOURCE[0]}")/_resync.sh" "post-merge"

--- a/bin/setup-hooks.js
+++ b/bin/setup-hooks.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+'use strict';
+
+// Cross-platform entry point for bin/setup-hooks.sh. npm always has node
+// available to run this (it's the runtime executing npm itself), which
+// bash/true are not guaranteed to be on every machine's PATH — notably a
+// default Git for Windows install only adds Git\cmd (git.exe) to PATH, not
+// Git\usr\bin (bash.exe, true.exe). A shell one-liner like
+// `bash bin/setup-hooks.sh || true` can itself fail to resolve `true` under
+// cmd.exe, turning a missing-bash environment into a hard `npm install`
+// failure instead of a harmless skip.
+//
+// Usage:
+//   node bin/setup-hooks.js          — propagates failure (manual run)
+//   node bin/setup-hooks.js --soft   — never exits non-zero (postinstall)
+
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+const soft = process.argv.includes('--soft');
+const script = path.join(__dirname, 'setup-hooks.sh');
+const result = spawnSync('bash', [script], { encoding: 'utf8' });
+
+if (result.error && result.error.code === 'ENOENT') {
+  console.warn(
+    'bash not found on PATH — skipping git hook setup. Install Git Bash (or WSL), ' +
+      "then run `npm run setup-hooks` manually so post-merge/post-checkout keep " +
+      '~/.claude/commands in sync.'
+  );
+  process.exit(soft ? 0 : 1);
+}
+
+if (result.stdout) process.stdout.write(result.stdout);
+if (result.stderr) process.stderr.write(result.stderr);
+
+if (result.status !== 0 && soft) {
+  console.warn(
+    `setup-hooks.sh exited with status ${result.status} — git hooks may not be wired up. ` +
+      "Run 'npm run setup-hooks' manually to retry."
+  );
+  process.exit(0);
+}
+
+process.exit(result.status ?? 0);

--- a/bin/setup-hooks.sh
+++ b/bin/setup-hooks.sh
@@ -17,6 +17,17 @@ if ! git -C "$REPO_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   exit 0
 fi
 
+# core.hooksPath is exclusive, not additive: once set, git stops looking in
+# .git/hooks/ entirely. Don't clobber a value someone else already chose
+# (personal hooks, husky, etc.) — leave it alone and say so instead.
+existing_hooks_path="$(git -C "$REPO_DIR" config --get core.hooksPath || true)"
+if [ -n "$existing_hooks_path" ] && [ "$existing_hooks_path" != "bin/hooks" ]; then
+  echo "warning: core.hooksPath is already set to '${existing_hooks_path}' — leaving it as-is instead of overwriting with 'bin/hooks'." >&2
+  echo "  Skill files won't auto-sync via git hooks. Either merge bin/hooks/post-merge and" >&2
+  echo "  bin/hooks/post-checkout into your existing hooks, or run 'npm run install-skills' manually after pulling changes." >&2
+  exit 0
+fi
+
 chmod +x "$REPO_DIR"/bin/hooks/post-merge "$REPO_DIR"/bin/hooks/post-checkout
 git -C "$REPO_DIR" config core.hooksPath bin/hooks
 

--- a/bin/setup-hooks.sh
+++ b/bin/setup-hooks.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Point git at the repo-tracked hooks in bin/hooks/, so post-merge and
+# post-checkout auto-run install-skills.sh and keep ~/.claude/commands in
+# sync (see issue #108). Safe to run multiple times.
+#
+# Usage:
+#   bash bin/setup-hooks.sh
+#
+# Runs automatically via `npm install` (postinstall).
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if ! git -C "$REPO_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "not a git repo — skipping git hook setup" >&2
+  exit 0
+fi
+
+chmod +x "$REPO_DIR"/bin/hooks/post-merge "$REPO_DIR"/bin/hooks/post-checkout
+git -C "$REPO_DIR" config core.hooksPath bin/hooks
+
+echo "git hooks path set to bin/hooks — post-merge/post-checkout will keep ~/.claude/commands in sync"

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "install-skills": "bash bin/install-skills.sh",
     "check-skills": "bash bin/check-skills.sh",
     "check-installed-skills": "bash bin/check-installed-skills.sh",
-    "setup-hooks": "bash bin/setup-hooks.sh",
-    "postinstall": "bash bin/setup-hooks.sh || true",
+    "setup-hooks": "node bin/setup-hooks.js",
+    "postinstall": "node bin/setup-hooks.js --soft",
     "test": "node --test __tests__/parser.test.js __tests__/insert.test.js __tests__/skill-checks.test.js __tests__/skill-sync.test.js && node -r tsx/cjs --test __tests__/period.test.ts __tests__/archive.test.ts __tests__/trends.test.ts __tests__/wip.test.ts __tests__/document.test.ts __tests__/paths.test.ts __tests__/filters.test.ts __tests__/cli.test.ts __tests__/daylog.test.ts __tests__/skill-consistency.test.ts"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "check-sync": "node build.js --check",
     "install-skills": "bash bin/install-skills.sh",
     "check-skills": "bash bin/check-skills.sh",
-    "test": "node --test __tests__/parser.test.js __tests__/insert.test.js __tests__/skill-checks.test.js && node -r tsx/cjs --test __tests__/period.test.ts __tests__/archive.test.ts __tests__/trends.test.ts __tests__/wip.test.ts __tests__/document.test.ts __tests__/paths.test.ts __tests__/filters.test.ts __tests__/cli.test.ts __tests__/daylog.test.ts __tests__/skill-consistency.test.ts"
+    "check-installed-skills": "bash bin/check-installed-skills.sh",
+    "setup-hooks": "bash bin/setup-hooks.sh",
+    "postinstall": "bash bin/setup-hooks.sh || true",
+    "test": "node --test __tests__/parser.test.js __tests__/insert.test.js __tests__/skill-checks.test.js __tests__/skill-sync.test.js && node -r tsx/cjs --test __tests__/period.test.ts __tests__/archive.test.ts __tests__/trends.test.ts __tests__/wip.test.ts __tests__/document.test.ts __tests__/paths.test.ts __tests__/filters.test.ts __tests__/cli.test.ts __tests__/daylog.test.ts __tests__/skill-consistency.test.ts"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary
- Adds git hooks (`post-merge`/`post-checkout`) that re-run `install-skills.sh` automatically after a pull, merge, or branch switch, so `~/.claude/commands` never drifts from the repo again
- `npm install` wires the hooks up via a new `postinstall`/`setup-hooks` script (`git config core.hooksPath bin/hooks`)
- Adds `bin/check-installed-skills.sh` (`npm run check-installed-skills`) as a manual way to diff the installed copies against the repo when in doubt
- Updates README/SETUP.md to document the new auto-sync behavior

Closes #108

## Code review fixes (2nd commit)
An 8-angle `/code-review high` pass (finders + independent 1-vote verifiers, several empirically reproduced) confirmed 6 real bugs, all fixed here:
1. **Worktree hook-path bug** — `post-merge`/`post-checkout` resolved the repo root via `git rev-parse --show-toplevel`, which returns a linked worktree's own ephemeral path (worktrees share `core.hooksPath`). Reproduced end-to-end: checking out a branch inside a worktree pointed `~/.claude/commands/*.md`'s `<<REPO_PATH>>` at the worktree, which then dangled once the worktree was removed. Fixed via a shared `bin/hooks/_resync.sh` that resolves the main repo through `--git-common-dir` instead.
2. **Hooks committed non-executable (100644)** — git silently skips non-executable hook files; confirmed via `git ls-files -s`. Fixed the tracked mode to 100755.
3. **`postinstall` bash hard-dependency** — `bash bin/setup-hooks.sh || true` could hard-fail `npm install` on Windows without git-bash on PATH (verified on this machine: `true` isn't resolvable under `cmd.exe` either, so the `|| true` fallback itself can fail). Replaced with `bin/setup-hooks.js`, a Node wrapper that never breaks `npm install` and prints a clear skip message instead.
4. **`core.hooksPath` clobber** — `setup-hooks.sh` unconditionally overwrote `core.hooksPath`, which is exclusive (confirmed empirically), silently disabling any pre-existing personal/husky hooks. Now leaves it alone and warns if it's already set to something else.
5. **Docs overclaimed "automatic"** — an existing clone that just does `git pull` to receive this fix doesn't get the hook wired up by that pull alone (`postinstall` only runs on `npm install`). Reworded SETUP.md/README.md to call out the one-time bootstrap step.
6. **Triplicated skill-file list** — `check-installed-skills.sh` had its own hardcoded copy of the 5 filenames; now derives them from `install-skills.sh`'s own materialized output.

Two other candidates were investigated and refuted: a bash-3.2/`nounset` empty-array concern (the script already uses the safe `${#arr[@]}` form) and a "skip re-sync when the checkout didn't touch skill files" efficiency suggestion (rejected — conflicts with the deliberate "always cheap, always idempotent" design this fix relies on).

## Test plan
- [x] `npm test` — 148/148 passing (138 unchanged + 10 in `__tests__/skill-sync.test.js`, including a real git-worktree regression test for fix #1 and bash-unavailable tests for fix #3)
- [x] `bash bin/check-skills.sh` — still passes
- [x] Verified live in this clone: `npm run setup-hooks` → `git checkout -b` prints `post-checkout: skill files re-synced to ~/.claude/commands` and actually rewrites the files

🤖 Generated with [Claude Code](https://claude.com/claude-code)